### PR TITLE
chore(test): `tst_cmakecommand_buildin` suppress failure

### DIFF
--- a/src/complete/buildin.rs
+++ b/src/complete/buildin.rs
@@ -103,12 +103,10 @@ mod tests {
     use std::process::Command;
     #[test]
     fn tst_cmakecommand_buildin() {
+        // NOTE: In case the command fails, ignore test
+        let Ok(output) = Command::new("cmake") .arg("--help-commands") .output() else { return; };
         let re = regex::Regex::new(r"[z-zA-z]+\n-+").unwrap();
-        let output = Command::new("cmake")
-            .arg("--help-commands")
-            .output()
-            .unwrap()
-            .stdout;
+        let output = output.stdout;
         let temp = String::from_utf8_lossy(&output);
         let _key: Vec<_> = re.find_iter(&temp).collect();
         let splits: Vec<_> = re.split(&temp).into_iter().collect();


### PR DESCRIPTION
Building neocmakelsp in sandbox environment (which doesn't have cmake) causes the build to fail. 

Ofc, there is a workaround by disabling tests all together or specifc test, but it would be nice if this paritcular test is ignored in such cases
