### PR TITLE
ci: add binary statically linked to musl

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,12 +47,30 @@ jobs:
         with:
           path: target/release/${{ matrix.artifact_name }}
           name: ${{ matrix.target }}
+  build-linux-musl:
+    name: Build Static
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+      BINARY_NAME: rust-test1
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build-musl Linux x86
+      uses: shogan/rust-musl-action@master
+      with:
+        args: cargo build --target x86_64-unknown-linux-musl --release
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        path: target/x86_64-unknown-linux-musl/release/neocmakelsp
+        name: x86_64-unknown-linux-musl
   release:
     permissions:
       contents: write
     if: startsWith(github.ref, 'refs/tags/v')
     needs:
       - build
+      - build-linux-musl
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v3
@@ -66,6 +84,7 @@ jobs:
           mv x86_64-apple-darwin/neocmakelsp out/neocmakelsp-x86_64-apple-darwin
           mv x86_64-pc-windows-msvc/neocmakelsp.exe out/neocmakelsp-x86_64-pc-windows-msvc.exe
           mv x86_64-unknown-linux-gnu/neocmakelsp out/neocmakelsp-x86_64-unknown-linux-gnu
+          mv x86_64-unknown-linux-musl/neocmakelsp out/neocmakelsp-x86_64-unknown-linux-musl
           cd out
           sha256sum * > sha256sum
       - name: Release


### PR DESCRIPTION
A new binary named neocmakelsp-x86_64-unknown-linux-musl is added.

This binary is staticly linked to musl, and can run without glibc.

sample output: https://github.com/yangyingchao/neocmakelsp/releases