### PR TITLE
Improve `include` diagnostics

### DIFF
--- a/src/gammar.rs
+++ b/src/gammar.rs
@@ -89,9 +89,8 @@ pub fn checkerror(local_path: &Path, source: &str, input: tree_sitter::Node) -> 
                         }
                         {
                             let path = Path::new(&first_arg);
-                            let is_last_char_sep = std::path::is_separator(
-                                first_arg.as_bytes()[first_arg.len() - 1] as char,
-                            );
+                            let is_last_char_sep =
+                                std::path::is_separator(first_arg.chars().last().unwrap());
                             if !is_last_char_sep && path.extension().is_none() {
                                 // first_arg could be a module
                                 continue;


### PR DESCRIPTION
- **fixes:** In windows include with relative path will not procude a warning. Previously `include(./some/valid/file.cmake)` produced a warnding message in windows.
- **fixes:** Path check will only be done for the first argument of the include function. Previously it considered all arguments as a single string.
- **feat:** Better diagnostic message for the invalid file path.
