### PR TITLE
better to use the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.6.23"
 edition = "2021"
 license = "MIT"
 description = "The Lsp for cmake"
-homepage = "https://github.com/Decodetalkers/neocmakelsp"
+repository = "https://github.com/Decodetalkers/neocmakelsp"
 authors = ["Decodertalkers <aakari@tutanota.com>"]
 keywords = ["lsp"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See also [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field).