### PR TITLE
feat: Update `CompletionItem` to meet the requirements of the LSP specification

### DIFF
--- a/src/complete.rs
+++ b/src/complete.rs
@@ -13,7 +13,9 @@ use std::sync::Arc;
 use tokio::fs;
 use tokio::sync::Mutex;
 use tower_lsp::lsp_types;
-use tower_lsp::lsp_types::{CompletionItem, CompletionItemKind, MessageType, Position};
+use tower_lsp::lsp_types::{
+    CompletionItem, CompletionItemKind, Documentation, MessageType, Position,
+};
 
 use once_cell::sync::Lazy;
 
@@ -34,7 +36,10 @@ pub fn rst_doc_read(doc: String, filename: &str) -> Vec<CompletionItem> {
         .map(|line| CompletionItem {
             label: line.to_string(),
             kind: Some(CompletionItemKind::FUNCTION),
-            detail: Some(format!("defined command from {filename}\n{doc}")),
+            detail: Some("Command".to_string()),
+            documentation: Some(Documentation::String(format!(
+                "defined command from {filename}\n{doc}"
+            ))),
             ..Default::default()
         })
         .collect()
@@ -213,7 +218,11 @@ fn getsubcomplete(
                 complete.push(CompletionItem {
                     label: name.to_string(),
                     kind: Some(CompletionItemKind::FUNCTION),
-                    detail: Some(format!("defined function\nfrom: {}", local_path.display())),
+                    detail: Some("Function".to_string()),
+                    documentation: Some(Documentation::String(format!(
+                        "defined function\nfrom: {}",
+                        local_path.display()
+                    ))),
                     ..Default::default()
                 });
             }
@@ -237,7 +246,11 @@ fn getsubcomplete(
                 complete.push(CompletionItem {
                     label: name.to_string(),
                     kind: Some(CompletionItemKind::FUNCTION),
-                    detail: Some(format!("defined function\nfrom: {}", local_path.display())),
+                    detail: Some("Function".to_string()),
+                    documentation: Some(Documentation::String(format!(
+                        "defined function\nfrom: {}",
+                        local_path.display()
+                    ))),
                     ..Default::default()
                 });
             }
@@ -334,10 +347,11 @@ fn getsubcomplete(
                             complete.push(CompletionItem {
                                 label: variable.to_string(),
                                 kind: Some(CompletionItemKind::VARIABLE),
-                                detail: Some(format!(
+                                detail: Some("Variable".to_string()),
+                                documentation: Some(Documentation::String(format!(
                                     "defined var\nfrom: {}",
                                     local_path.display()
-                                )),
+                                ))),
                                 ..Default::default()
                             });
                         }
@@ -368,10 +382,11 @@ fn getsubcomplete(
                                 complete.push(CompletionItem {
                                     label: name.to_string(),
                                     kind: Some(CompletionItemKind::VALUE),
-                                    detail: Some(format!(
+                                    detail: Some("Value".to_string()),
+                                    documentation: Some(Documentation::String(format!(
                                         "defined variable\nfrom: {}",
                                         local_path.display()
-                                    )),
+                                    ))),
                                     ..Default::default()
                                 });
                             }
@@ -433,7 +448,10 @@ fn getsubcomplete(
                                         complete.push(CompletionItem {
                                             label: component,
                                             kind: Some(CompletionItemKind::VARIABLE),
-                                            detail: Some(format!("package from: {package_name}",)),
+                                            detail: Some("Variable".to_string()),
+                                            documentation: Some(Documentation::String(format!(
+                                                "package from: {package_name}",
+                                            ))),
                                             ..Default::default()
                                         });
                                     }
@@ -446,7 +464,10 @@ fn getsubcomplete(
                                     complete.push(CompletionItem {
                                         label: format!("{package_name}_LIBRARIES"),
                                         kind: Some(CompletionItemKind::VARIABLE),
-                                        detail: Some(format!("package: {package_name}",)),
+                                        detail: Some("Variable".to_string()),
+                                        documentation: Some(Documentation::String(format!(
+                                            "package: {package_name}",
+                                        ))),
                                         ..Default::default()
                                     });
                                 }
@@ -458,7 +479,10 @@ fn getsubcomplete(
                                     complete.push(CompletionItem {
                                         label: format!("{package_name}_INCLUDE_DIRS"),
                                         kind: Some(CompletionItemKind::VARIABLE),
-                                        detail: Some(format!("package: {package_name}",)),
+                                        detail: Some("Variable".to_string()),
+                                        documentation: Some(Documentation::String(format!(
+                                            "package: {package_name}",
+                                        ))),
                                         ..Default::default()
                                     });
                                 }
@@ -517,7 +541,10 @@ fn getsubcomplete(
                                     complete.push(CompletionItem {
                                         label: format!("PkgConfig::{package_name}"),
                                         kind: Some(CompletionItemKind::VARIABLE),
-                                        detail: Some(format!("package: {package_name}",)),
+                                        detail: Some("Package".to_string()),
+                                        documentation: Some(Documentation::String(format!(
+                                            "package: {package_name}",
+                                        ))),
                                         ..Default::default()
                                     });
                                 }
@@ -529,7 +556,10 @@ fn getsubcomplete(
                                     complete.push(CompletionItem {
                                         label: format!("{package_name}_LIBRARIES"),
                                         kind: Some(CompletionItemKind::VARIABLE),
-                                        detail: Some(format!("package: {package_name}",)),
+                                        detail: Some("Package".to_string()),
+                                        documentation: Some(Documentation::String(format!(
+                                            "package: {package_name}",
+                                        ))),
                                         ..Default::default()
                                     });
                                 }
@@ -540,7 +570,10 @@ fn getsubcomplete(
                                     complete.push(CompletionItem {
                                         label: format!("{package_name}_INCLUDE_DIRS"),
                                         kind: Some(CompletionItemKind::VARIABLE),
-                                        detail: Some(format!("package: {package_name}",)),
+                                        detail: Some("Package".to_string()),
+                                        documentation: Some(Documentation::String(format!(
+                                            "package: {package_name}",
+                                        ))),
                                         ..Default::default()
                                     });
                                 }

--- a/src/complete/buildin.rs
+++ b/src/complete/buildin.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use once_cell::sync::Lazy;
 use std::process::Command;
 use std::{collections::HashMap, iter::zip};
-use tower_lsp::lsp_types::{CompletionItem, CompletionItemKind};
+use tower_lsp::lsp_types::{CompletionItem, CompletionItemKind, Documentation};
 
 /// CMake build in commands
 pub static BUILDIN_COMMAND: Lazy<Result<Vec<CompletionItem>>> = Lazy::new(|| {
@@ -45,8 +45,9 @@ pub static BUILDIN_COMMAND: Lazy<Result<Vec<CompletionItem>>> = Lazy::new(|| {
         .iter()
         .map(|(akey, message)| CompletionItem {
             label: akey.to_string(),
-            kind: Some(CompletionItemKind::MODULE),
-            detail: Some(message.to_string()),
+            kind: Some(CompletionItemKind::FUNCTION),
+            detail: Some("Function".to_string()),
+            documentation: Some(Documentation::String(message.to_string())),
             ..Default::default()
         })
         .collect())
@@ -73,7 +74,8 @@ pub static BUILDIN_VARIABLE: Lazy<Result<Vec<CompletionItem>>> = Lazy::new(|| {
         .map(|(akey, message)| CompletionItem {
             label: akey.to_string(),
             kind: Some(CompletionItemKind::VARIABLE),
-            detail: Some(message.to_string()),
+            detail: Some("Variable".to_string()),
+            documentation: Some(Documentation::String(message.to_string())),
             ..Default::default()
         })
         .collect())
@@ -97,7 +99,8 @@ pub static BUILDIN_MODULE: Lazy<Result<Vec<CompletionItem>>> = Lazy::new(|| {
         .map(|(akey, message)| CompletionItem {
             label: akey.to_string(),
             kind: Some(CompletionItemKind::MODULE),
-            detail: Some(message.to_string()),
+            detail: Some("Module".to_string()),
+            documentation: Some(Documentation::String(message.to_string())),
             ..Default::default()
         })
         .collect())

--- a/src/complete/findpackage.rs
+++ b/src/complete/findpackage.rs
@@ -1,5 +1,5 @@
 use crate::utils;
-use lsp_types::{CompletionItem, CompletionItemKind};
+use lsp_types::{CompletionItem, CompletionItemKind, Documentation};
 use once_cell::sync::Lazy;
 use tower_lsp::lsp_types;
 pub static CMAKE_SOURCE: Lazy<Vec<CompletionItem>> = Lazy::new(|| {
@@ -8,13 +8,14 @@ pub static CMAKE_SOURCE: Lazy<Vec<CompletionItem>> = Lazy::new(|| {
         .map(|package| CompletionItem {
             label: package.name.clone(),
             kind: Some(CompletionItemKind::MODULE),
-            detail: Some(match &package.version {
+            detail: Some("Module".to_string()),
+            documentation: Some(Documentation::String(match &package.version {
                 None => format!("name:{}\nFiletype:{}\n", package.name, package.filetype),
                 Some(version) => format!(
                     "name:{}\nFiletype:{}\nversion:{}",
                     package.name, package.filetype, version
                 ),
-            }),
+            })),
             ..Default::default()
         })
         .collect()
@@ -27,7 +28,11 @@ pub static PKGCONFIG_SOURCE: Lazy<Vec<CompletionItem>> = Lazy::new(|| {
         .map(|package| CompletionItem {
             label: package.libname.clone(),
             kind: Some(CompletionItemKind::MODULE),
-            detail: Some(format!("{}\n{}", package.libname, package.path)),
+            detail: Some("Module".to_string()),
+            documentation: Some(Documentation::String(format!(
+                "{}\n{}",
+                package.libname, package.path
+            ))),
             ..Default::default()
         })
         .collect()


### PR DESCRIPTION

Basically:
- detail: should be a human-readable string with additional information about this item, like type or symbol information.
- documentation: should be a human-readable string that represents a doc-comment.

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionItem

This may make nc change behavior when doing completion, but it should be consistent with other language servers.

Please feel free to close it if the previous behavior is "working as designed".
