### PR TITLE
format: don't introduce space before commented line

### DIFF
--- a/assets_for_test/base/formatafter.cmake
+++ b/assets_for_test/base/formatafter.cmake
@@ -2,4 +2,8 @@ set(
 	A 10
 )
 
-set(B 11)
+set(B 11) # comment
+
+set(C 12
+# D 13
+)

--- a/assets_for_test/base/formatbefore.cmake
+++ b/assets_for_test/base/formatbefore.cmake
@@ -2,4 +2,8 @@ set(
 	A 10
 )
 
-set(B 11)
+set(B 11)# comment
+
+set(C 12
+	# D 13
+)

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -67,6 +67,9 @@ fn pre_format(
             let linebefore = &line[..column];
             let linebefore = restrict_format_part(linebefore, row, child);
             let lineafter = &line[column..];
+            if linebefore.chars().all(|c| c.is_whitespace()) {
+                return lineafter.to_string();
+            }
             return format!("{linebefore} {lineafter}");
         }
     }
@@ -312,6 +315,16 @@ fn tst_format_base() {
     let formatstr_with_lastline = get_format_cli(source, 1, false, true).unwrap();
     assert_eq!(formatstr.as_str(), sourceafter);
     assert_eq!(formatstr_with_lastline.as_str(), sourceafter);
+}
+
+#[cfg(unix)]
+#[test]
+fn tst_format_base_second_call() {
+    let source = include_str!("../assets_for_test/base/formatbefore.cmake");
+    let sourceafter = include_str!("../assets_for_test/base/formatafter.cmake");
+    let formatstr = get_format_cli(source, 1, false, false).unwrap();
+    let formatstr = get_format_cli(&formatstr, 1, false, false).unwrap();
+    assert_eq!(formatstr.as_str(), sourceafter);
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
Fix #186

From a debugging session, I have found this fix that allows to fix my issue.
All the tests pass but I am not entirely sure to not break anything else.