### PR TITLE
ci: run lints and tests on each platform only once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,47 @@
 ---
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -D warnings
 
 jobs:
+  test:
+    name: Lint and test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - macos-15
+          - ubuntu-24.04
+          - windows-2025
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+      - uses: Swatinem/rust-cache@v2
+      - name: Lint (clippy)
+        run: cargo clippy --all-targets
+      - name: Lint (rustfmt)
+        run: cargo fmt --check
+      - name: Test
+        run: cargo test --all-targets
+
   typos:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ env:
     CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER: "arm-linux-gnueabihf-gcc"
 
 jobs:
-    build:
+    release-build:
         name: Build Binary
         strategy:
             matrix:
@@ -58,12 +58,6 @@ jobs:
                 sudo apt install -y musl-tools gcc-aarch64-linux-gnu gcc-arm-linux-gnueabihf
             - name: Build
               run: cargo build --target ${{ matrix.target }} --verbose --release
-            - name: Run fmt check
-              run: cargo fmt --all -- --check
-            - name: Run clippy check
-              run: cargo clippy -- -D warnings
-            - name: Run tests
-              run: cargo test --verbose
             - name: Upload artifacts
               uses: actions/upload-artifact@v5
               with:
@@ -75,7 +69,7 @@ jobs:
             contents: write
         if: startsWith(github.ref, 'refs/tags/v')
         needs:
-            - build
+            - release-build
         runs-on: ubuntu-latest
         steps:
             - uses: actions/download-artifact@v6


### PR DESCRIPTION
We don't have any architecture specific code so it's enough to run lints and tests on each platform once, using the runner's native architecture since it's the fastest (arm64 on macOS, x86_64 everywhere else).

I also added a caching action that speeds up subsequent build by a lot.

And I moved this to the `ci.yml` file since I think it makes more sense to split the (fast) debug builds for regular CI away from the release builds of the master branch, where more targets should be build anyways.