### PR TITLE
refactor: use dashmap to cache documents in backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,6 +653,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "cli-table",
+ "dashmap",
  "dirs",
  "glob",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ anyhow = "1.0.100"
 clap = { version = "4.5.51", features = ["derive"] }
 clap_complete = { version = "4.5.60", features = ["unstable-dynamic"] }
 cli-table = "0.5.0"
+dashmap = "6.1.0"
 dirs = "6.0.0"
 glob = "0.3.3"
 ignore = "0.4.25"

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use clap::{CommandFactory, Parser};
+use dashmap::DashMap;
 use ignore::Walk;
 use ini::Ini;
 use tower_lsp::{Client, LspService, Server};
@@ -53,8 +54,8 @@ impl Default for BackendInitInfo {
 
 #[derive(Debug)]
 struct Backend {
-    /// client
     client: Client,
+    documents: DashMap<Uri, String>,
     /// Storage the message of buffers
     init_info: OnceLock<BackendInitInfo>,
     root_path: OnceLock<Option<PathBuf>>,
@@ -64,6 +65,7 @@ impl Backend {
     fn new(client: Client) -> Self {
         Self {
             client,
+            documents: DashMap::new(),
             init_info: OnceLock::new(),
             root_path: OnceLock::new(),
         }

--- a/src/rename.rs
+++ b/src/rename.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 
+use dashmap::DashMap;
 use tower_lsp::lsp_types::{Location, Position, TextEdit, Uri, WorkspaceEdit};
 
 use crate::jump;
@@ -11,9 +12,10 @@ pub async fn rename<P: AsRef<Path>>(
     originuri: P,
     client: &tower_lsp::Client,
     source: &str,
+    documents: &DashMap<Uri, String>,
 ) -> Option<WorkspaceEdit> {
     let mut changes: HashMap<Uri, Vec<TextEdit>> = HashMap::new();
-    let defs = jump::godef(location, source, originuri, client, false, true).await?;
+    let defs = jump::godef(location, source, originuri, client, false, true, documents).await?;
 
     for Location { uri, range } in defs {
         let edits = changes.entry(uri).or_default();


### PR DESCRIPTION
This is a preparation to cache more information like the tree sitter root to avoid re-parsing for every LSP action.

It will use a `dashmap`, which is a indirect dependency anyway.