### PR TITLE
fix: format within the biggest source range

### DIFF
--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -206,7 +206,10 @@ pub async fn getformat(
             Ok(new_source) => new_source,
         };
 
-        let lines = new_source.chars().filter(|c| *c == '\n').count();
+        let lines = std::cmp::max(
+            source.chars().filter(|c| *c == '\n').count(),
+            new_source.chars().filter(|c| *c == '\n').count(),
+        );
 
         return Some(vec![TextEdit {
             range: lsp_types::Range {


### PR DESCRIPTION
Currently, the range to apply the changes to after formatting is defined by the number of newline characters in the resulting string. Unfortunately, this doesn't take into account the case where that resulting string is shorter than the original one, thus leaving the content outside of the range unchanged. Here's what it looks like:

https://github.com/user-attachments/assets/4ca168ea-b1af-45e7-ac4c-fb9edff25b32

The suggested change chooses the maximum amount of newline characters between both the original and resulting strings. Here's the result:

https://github.com/user-attachments/assets/b36211a0-9b7a-4edf-93df-5a07d01faa7a