### PR TITLE
fix(deps)!: switch to using etcetera for choosing config directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,27 +312,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
-name = "dirs"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "dlv-list"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +333,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
+dependencies = [
+ "cfg-if",
  "windows-sys 0.61.2",
 ]
 
@@ -582,16 +571,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5a2d376baa530d1238d133232d15e239abad80d05838b4b59354e5268af431f"
 
 [[package]]
-name = "libredox"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
-dependencies = [
- "bitflags",
- "libc",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,7 +633,7 @@ dependencies = [
  "clap_complete",
  "cli-table",
  "dashmap",
- "dirs",
+ "etcetera",
  "glob",
  "ignore",
  "path-absolutize",
@@ -695,12 +674,6 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-multimap"
@@ -835,17 +808,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
-dependencies = [
- "getrandom 0.2.16",
- "libredox",
- "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ clap = { version = "4.5.54", features = ["derive"] }
 clap_complete = { version = "4.5.65", features = ["unstable-dynamic"] }
 cli-table = "0.5.0"
 dashmap = "6.1.0"
-dirs = "6.0.0"
+etcetera = "0.11.0"
 glob = "0.3.3"
 ignore = "0.4.25"
 pathdiff = "0.2.3"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::sync::LazyLock;
 
-use dirs::config_dir;
+use etcetera::{BaseStrategy, choose_base_strategy};
 use serde::Deserialize;
 
 #[derive(Deserialize, PartialEq, Eq, Debug)]
@@ -90,13 +90,14 @@ fn find_config_file() -> Option<PathBuf> {
         }
     }
 
-    if let Some(config_dir) = config_dir() {
-        for file in ["config.toml", "lint.toml"] {
-            let path = config_dir.join("neocmakelsp").join(file);
-            if path.exists() {
-                tracing::info!("Using user-level config file: {:?}", path);
-                return Some(path);
-            }
+    let strategy = choose_base_strategy().ok()?;
+    let config_dir = strategy.config_dir();
+
+    for file in ["config.toml", "lint.toml"] {
+        let path = config_dir.join("neocmakelsp").join(file);
+        if path.exists() {
+            tracing::info!("Using user-level config file: {:?}", path);
+            return Some(path);
         }
     }
 


### PR DESCRIPTION
The dirs crate is known to not respect conventions on macOS and the creators are not willing to change that.

Closes: https://github.com/neocmakelsp/neocmakelsp/issues/232
Ref: https://codeberg.org/dirs/directories-rs/issues/47