### PR TITLE
refactor: switch to tower-lsp-server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,17 +83,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "auto_impl"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,12 +349,13 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fluent-uri"
-version = "0.3.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1918b65d96df47d3591bed19c5cca17e3fa5d0707318e4b5ef2eae01764df7e5"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
 dependencies = [
  "borrow-or-share",
  "ref-cast",
+ "serde",
 ]
 
 [[package]]
@@ -630,18 +620,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
-name = "lsp-types-f"
-version = "0.99.0"
+name = "ls-types"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d628780e3ad5c81cadfa96c06840d85ba76b5f79b74c4edddd86931ac409cd9"
+checksum = "c029d4b509074b7d59dac432d87d4c24badaaf6c6c9c8b7ac030ae8022dc118d"
 dependencies = [
  "bitflags",
  "fluent-uri",
  "percent-encoding",
  "serde",
  "serde_json",
- "serde_repr",
- "thiserror",
 ]
 
 [[package]]
@@ -685,7 +673,7 @@ dependencies = [
  "tokio",
  "toml",
  "tower",
- "tower-lsp-f",
+ "tower-lsp-server",
  "tracing",
  "tracing-subscriber",
  "tree-sitter",
@@ -1003,17 +991,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_repr"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "serde_spanned"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1125,26 +1102,6 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
-
-[[package]]
-name = "thiserror"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "thread_local"
@@ -1265,17 +1222,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
-name = "tower-lsp-f"
-version = "0.24.0"
+name = "tower-lsp-server"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce19374023feda27c245b9a9f2a8e4fea6669c489ea2b2cdb1017d41ed3c45b"
+checksum = "2f0e711655c89181a6bc6a2cc348131fcd9680085f5b06b6af13427a393a6e72"
 dependencies = [
- "auto_impl",
  "bytes",
  "dashmap",
  "futures",
  "httparse",
- "lsp-types-f",
+ "ls-types",
  "memchr",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 tokio = { version = "1.49.0", features = ["full"] }
 toml = "1.0.3"
-tower-lsp = { version = "0.24.0", package = "tower-lsp-f" }
+tower-lsp = { version = "0.23.0", package = "tower-lsp-server" }
 tracing = "0.1.44"
 tracing-subscriber = "0.3.22"
 tree-sitter = "0.26.5"

--- a/src/complete.rs
+++ b/src/complete.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, LazyLock};
 use builtin::{BUILTIN_COMMAND, BUILTIN_MODULE, BUILTIN_VARIABLE};
 use dashmap::DashMap;
 use tokio::sync::Mutex;
-use tower_lsp::lsp_types::{
+use tower_lsp::ls_types::{
     CompletionItem, CompletionItemKind, CompletionResponse, Documentation, MessageType, Position,
     Uri,
 };
@@ -17,11 +17,10 @@ use crate::consts::TREESITTER_CMAKE_LANGUAGE;
 use crate::fileapi;
 use crate::languageserver::get_or_update_buffer_contents;
 use crate::scansubs::TREE_MAP;
-use crate::utils::treehelper::{PositionType, ToPoint, get_pos_type};
-
 use crate::utils::query::{
     get_bracket_comments, get_functions, get_line_comments, get_macros, get_normal_commands,
 };
+use crate::utils::treehelper::{PositionType, ToPoint, get_pos_type};
 use crate::utils::{
     CACHE_CMAKE_PACKAGES_WITHKEYS, gen_module_pattern, include_is_module,
     remove_quotation_and_replace_placeholders,

--- a/src/complete/builtin.rs
+++ b/src/complete/builtin.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 use std::sync::LazyLock;
 
 use anyhow::Result;
-use tower_lsp::lsp_types::{CompletionItem, CompletionItemKind, Documentation, InsertTextFormat};
+use tower_lsp::ls_types::{CompletionItem, CompletionItemKind, Documentation, InsertTextFormat};
 
 use crate::languageserver::to_use_snippet;
 

--- a/src/complete/findpackage.rs
+++ b/src/complete/findpackage.rs
@@ -1,6 +1,6 @@
 use std::sync::LazyLock;
 
-use tower_lsp::lsp_types::{CompletionItem, CompletionItemKind, Documentation};
+use tower_lsp::ls_types::{CompletionItem, CompletionItemKind, Documentation};
 
 use crate::utils::CACHE_CMAKE_PACKAGES;
 

--- a/src/complete/includescanner.rs
+++ b/src/complete/includescanner.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::sync::{Arc, LazyLock, Mutex};
 
-use tower_lsp::lsp_types::CompletionItem;
+use tower_lsp::ls_types::CompletionItem;
 
 use super::getsubcomplete;
 use crate::consts::TREESITTER_CMAKE_LANGUAGE;
@@ -94,7 +94,7 @@ mod tests {
     use std::io::Write;
 
     use tempfile::tempdir;
-    use tower_lsp::lsp_types::{CompletionItemKind, Documentation};
+    use tower_lsp::ls_types::{CompletionItemKind, Documentation};
 
     use super::*;
 

--- a/src/document_link.rs
+++ b/src/document_link.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use tower_lsp::lsp_types::{DocumentLink, Position, Range};
+use tower_lsp::ls_types::{DocumentLink, Position, Range};
 
 use crate::Uri;
 use crate::consts::TREESITTER_CMAKE_LANGUAGE;

--- a/src/document_symbol.rs
+++ b/src/document_symbol.rs
@@ -1,5 +1,5 @@
-use lsp_types::{DocumentSymbol, DocumentSymbolResponse, MessageType, SymbolKind};
-use tower_lsp::{Client, lsp_types};
+use ls_types::{DocumentSymbol, DocumentSymbolResponse, MessageType, SymbolKind};
+use tower_lsp::{Client, ls_types};
 
 use crate::CMakeNodeKinds;
 use crate::consts::TREESITTER_CMAKE_LANGUAGE;
@@ -57,22 +57,22 @@ fn get_sub_symbol(
                     kind: SymbolKind::FUNCTION,
                     tags: None,
                     deprecated: None,
-                    range: lsp_types::Range {
-                        start: lsp_types::Position {
+                    range: ls_types::Range {
+                        start: ls_types::Position {
                             line: child.start_position().row as u32,
                             character: child.start_position().column as u32,
                         },
-                        end: lsp_types::Position {
+                        end: ls_types::Position {
                             line: child.end_position().row as u32,
                             character: child.end_position().column as u32,
                         },
                     },
-                    selection_range: lsp_types::Range {
-                        start: lsp_types::Position {
+                    selection_range: ls_types::Range {
+                        start: ls_types::Position {
                             line: child.start_position().row as u32,
                             character: child.start_position().column as u32,
                         },
-                        end: lsp_types::Position {
+                        end: ls_types::Position {
                             line: child.end_position().row as u32,
                             character: child.end_position().column as u32,
                         },
@@ -103,22 +103,22 @@ fn get_sub_symbol(
                     kind: SymbolKind::FUNCTION,
                     tags: None,
                     deprecated: None,
-                    range: lsp_types::Range {
-                        start: lsp_types::Position {
+                    range: ls_types::Range {
+                        start: ls_types::Position {
                             line: child.start_position().row as u32,
                             character: child.start_position().column as u32,
                         },
-                        end: lsp_types::Position {
+                        end: ls_types::Position {
                             line: child.end_position().row as u32,
                             character: child.end_position().column as u32,
                         },
                     },
-                    selection_range: lsp_types::Range {
-                        start: lsp_types::Position {
+                    selection_range: ls_types::Range {
+                        start: ls_types::Position {
                             line: child.start_position().row as u32,
                             character: child.start_position().column as u32,
                         },
-                        end: lsp_types::Position {
+                        end: ls_types::Position {
                             line: child.end_position().row as u32,
                             character: child.end_position().column as u32,
                         },
@@ -143,22 +143,22 @@ fn get_sub_symbol(
                     kind: SymbolKind::NAMESPACE,
                     tags: None,
                     deprecated: None,
-                    range: lsp_types::Range {
-                        start: lsp_types::Position {
+                    range: ls_types::Range {
+                        start: ls_types::Position {
                             line: child.start_position().row as u32,
                             character: child.start_position().column as u32,
                         },
-                        end: lsp_types::Position {
+                        end: ls_types::Position {
                             line: child.end_position().row as u32,
                             character: child.end_position().column as u32,
                         },
                     },
-                    selection_range: lsp_types::Range {
-                        start: lsp_types::Position {
+                    selection_range: ls_types::Range {
+                        start: ls_types::Position {
                             line: child.start_position().row as u32,
                             character: child.start_position().column as u32,
                         },
-                        end: lsp_types::Position {
+                        end: ls_types::Position {
                             line: child.end_position().row as u32,
                             character: child.end_position().column as u32,
                         },
@@ -203,13 +203,13 @@ fn get_sub_symbol(
                             kind: SymbolKind::VARIABLE,
                             tags: None,
                             deprecated: None,
-                            range: lsp_types::Range { start, end },
-                            selection_range: lsp_types::Range {
-                                start: lsp_types::Position {
+                            range: ls_types::Range { start, end },
+                            selection_range: ls_types::Range {
+                                start: ls_types::Position {
                                     line: h as u32,
                                     character: x as u32,
                                 },
-                                end: lsp_types::Position {
+                                end: ls_types::Position {
                                     line: h as u32,
                                     character: y as u32,
                                 },

--- a/src/fileapi.rs
+++ b/src/fileapi.rs
@@ -7,7 +7,7 @@ use std::sync::{LazyLock, Mutex};
 use cache::Cache;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use tower_lsp::lsp_types::CompletionItem;
+use tower_lsp::ls_types::CompletionItem;
 
 static CACHE_DATA: LazyLock<Mutex<Option<Cache>>> = LazyLock::new(|| Mutex::new(None));
 

--- a/src/fileapi/cache.rs
+++ b/src/fileapi/cache.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use tower_lsp::lsp_types::{CompletionItem, CompletionItemKind, Documentation};
+use tower_lsp::ls_types::{CompletionItem, CompletionItemKind, Documentation};
 
 use super::ApiVersion;
 

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -4,10 +4,10 @@ use std::path::Path;
 use std::process::Stdio;
 
 use anyhow::{Context, Result};
-use lsp_types::{MessageType, Position, TextEdit};
+use ls_types::{MessageType, Position, TextEdit};
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
-use tower_lsp::lsp_types;
+use tower_lsp::ls_types;
 
 use crate::CMakeNodeKinds;
 use crate::config::CONFIG;
@@ -214,7 +214,7 @@ pub async fn getformat(
         );
 
         return Some(vec![TextEdit {
-            range: lsp_types::Range {
+            range: ls_types::Range {
                 start: Position {
                     line: 0,
                     character: 0,
@@ -259,7 +259,7 @@ pub async fn getformat(
     let len_origin = source.lines().count();
     let len = std::cmp::max(len_count, len_origin);
     Some(vec![TextEdit {
-        range: lsp_types::Range {
+        range: ls_types::Range {
             start: Position {
                 line: 0,
                 character: 0,

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use std::process::Command;
 use std::sync::LazyLock;
 
-use tower_lsp::lsp_types::DiagnosticSeverity;
+use tower_lsp::ls_types::DiagnosticSeverity;
 use tree_sitter::{Point, Query, QueryCursor, StreamingIterator};
 
 use crate::config::{self, CONFIG};

--- a/src/hover.rs
+++ b/src/hover.rs
@@ -1,5 +1,5 @@
-use lsp_types::Position;
-use tower_lsp::lsp_types;
+use ls_types::Position;
+use tower_lsp::ls_types;
 use tree_sitter::Node;
 
 use crate::fileapi;

--- a/src/jump.rs
+++ b/src/jump.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, LazyLock};
 
 use dashmap::DashMap;
 use tokio::sync::Mutex;
-use tower_lsp::lsp_types::{Location, MessageType, Position, Range, Uri};
+use tower_lsp::ls_types::{Location, MessageType, Position, Range, Uri};
 
 use crate::languageserver::get_or_update_buffer_contents;
 use crate::scansubs::TREE_CMAKE_MAP;
@@ -24,11 +24,10 @@ mod include;
 mod subdirectory;
 use tree_sitter::Node;
 
-use crate::utils::treehelper::{PositionType, get_pos_type};
-
 use crate::utils::query::{
     get_functions, get_line_comments, get_macros, get_normal_commands, get_variables,
 };
+use crate::utils::treehelper::{PositionType, get_pos_type};
 
 /// Storage the information when jump
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -232,7 +231,7 @@ async fn godef_inner<P: AsRef<Path>>(
                 return Some(vec![jump_cache]);
             }
 
-            let loc = jump_cache.uri.to_file_path().ok()?;
+            let loc = jump_cache.uri.to_file_path()?;
             locations.push(jump_cache.clone());
             let mut defdata = reference_all(&loc, tofind, is_function).await;
             locations.append(&mut defdata);
@@ -626,7 +625,7 @@ mod tests {
     use std::io::Write;
 
     use tempfile::tempdir;
-    use tower_lsp::lsp_types;
+    use tower_lsp::ls_types;
     use tree_sitter::Point;
 
     use super::*;
@@ -659,12 +658,12 @@ mod tests {
             locations,
             vec![Location {
                 uri: Uri::from_file_path(subdir_file).unwrap(),
-                range: lsp_types::Range {
-                    start: lsp_types::Position {
+                range: ls_types::Range {
+                    start: ls_types::Position {
                         line: 0,
                         character: 0,
                     },
-                    end: lsp_types::Position {
+                    end: ls_types::Position {
                         line: 0,
                         character: 0,
                     },
@@ -707,12 +706,12 @@ add_subdirectory(abcd_test)
             locations,
             vec![Location {
                 uri: Uri::from_file_path(&top_cmake).unwrap(),
-                range: lsp_types::Range {
-                    start: lsp_types::Position {
+                range: ls_types::Range {
+                    start: ls_types::Position {
                         line: 1,
                         character: 4,
                     },
-                    end: lsp_types::Position {
+                    end: ls_types::Position {
                         line: 1,
                         character: 8,
                     },
@@ -734,12 +733,12 @@ add_subdirectory(abcd_test)
             locations_2,
             vec![Location {
                 uri: Uri::from_file_path(top_cmake).unwrap(),
-                range: lsp_types::Range {
-                    start: lsp_types::Position {
+                range: ls_types::Range {
+                    start: ls_types::Position {
                         line: 3,
                         character: 4,
                     },
-                    end: lsp_types::Position {
+                    end: ls_types::Position {
                         line: 3,
                         character: 12,
                     },
@@ -793,12 +792,12 @@ include(efg_test.cmake)
                 key: "ABCD".to_string(),
                 location: Location {
                     uri: Uri::from_file_path(&include_cmake_path).unwrap(),
-                    range: lsp_types::Range {
-                        start: lsp_types::Position {
+                    range: ls_types::Range {
+                        start: ls_types::Position {
                             line: 1,
                             character: 4
                         },
-                        end: lsp_types::Position {
+                        end: ls_types::Position {
                             line: 1,
                             character: 8
                         }

--- a/src/jump/findpackage.rs
+++ b/src/jump/findpackage.rs
@@ -1,5 +1,5 @@
-use lsp_types::Uri;
-use tower_lsp::lsp_types;
+use ls_types::Uri;
+use tower_lsp::ls_types;
 
 use super::Location;
 use crate::utils::CACHE_CMAKE_PACKAGES_WITHKEYS;
@@ -10,12 +10,12 @@ pub(super) fn cmpfindpackage(input: &str) -> Option<Vec<Location>> {
             .tojump
             .iter()
             .map(|apath| Location {
-                range: lsp_types::Range {
-                    start: lsp_types::Position {
+                range: ls_types::Range {
+                    start: ls_types::Position {
                         line: 0,
                         character: 0,
                     },
-                    end: lsp_types::Position {
+                    end: ls_types::Position {
                         line: 0,
                         character: 0,
                     },
@@ -46,12 +46,12 @@ mod tests {
         assert_eq!(
             location_fake,
             vec![Location {
-                range: lsp_types::Range {
-                    start: lsp_types::Position {
+                range: ls_types::Range {
+                    start: ls_types::Position {
                         line: 0,
                         character: 0,
                     },
-                    end: lsp_types::Position {
+                    end: ls_types::Position {
                         line: 0,
                         character: 0,
                     },

--- a/src/jump/include.rs
+++ b/src/jump/include.rs
@@ -3,8 +3,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, LazyLock, Mutex};
 
-use lsp_types::Uri;
-use tower_lsp::lsp_types;
+use ls_types::Uri;
+use tower_lsp::ls_types;
 
 use super::{CacheDataUnit, Location, gen_module_pattern, getsubdef};
 use crate::consts::TREESITTER_CMAKE_LANGUAGE;
@@ -26,12 +26,12 @@ pub(super) fn cmpinclude<P: AsRef<Path>>(localpath: P, subpath: &str) -> Option<
 
     if target.exists() {
         Some(vec![Location {
-            range: lsp_types::Range {
-                start: lsp_types::Position {
+            range: ls_types::Range {
+                start: ls_types::Position {
                     line: 0,
                     character: 0,
                 },
-                end: lsp_types::Position {
+                end: ls_types::Position {
                     line: 0,
                     character: 0,
                 },
@@ -142,12 +142,12 @@ mod tests {
         assert_eq!(
             locations,
             vec![Location {
-                range: lsp_types::Range {
-                    start: lsp_types::Position {
+                range: ls_types::Range {
+                    start: ls_types::Position {
                         line: 0,
                         character: 0,
                     },
-                    end: lsp_types::Position {
+                    end: ls_types::Position {
                         line: 0,
                         character: 0,
                     },
@@ -196,12 +196,12 @@ include(efg_test.cmake)
                 key: "ABCD".to_string(),
                 location: Location {
                     uri: Uri::from_file_path(&include_cmake_path).unwrap(),
-                    range: lsp_types::Range {
-                        start: lsp_types::Position {
+                    range: ls_types::Range {
+                        start: ls_types::Position {
                             line: 1,
                             character: 4
                         },
-                        end: lsp_types::Position {
+                        end: ls_types::Position {
                             line: 1,
                             character: 8
                         }

--- a/src/jump/subdirectory.rs
+++ b/src/jump/subdirectory.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
-use lsp_types::Uri;
-use tower_lsp::lsp_types;
+use ls_types::Uri;
+use tower_lsp::ls_types;
 
 use super::Location;
 
@@ -13,12 +13,12 @@ pub(super) fn cmpsubdirectory<P: AsRef<Path>>(
     let target = dir.join(subpath).join("CMakeLists.txt");
     if target.exists() {
         return Some(vec![Location {
-            range: lsp_types::Range {
-                start: lsp_types::Position {
+            range: ls_types::Range {
+                start: ls_types::Position {
                     line: 0,
                     character: 0,
                 },
-                end: lsp_types::Position {
+                end: ls_types::Position {
                     line: 0,
                     character: 0,
                 },
@@ -53,12 +53,12 @@ mod tests {
         assert_eq!(
             locations,
             vec![Location {
-                range: lsp_types::Range {
-                    start: lsp_types::Position {
+                range: ls_types::Range {
+                    start: ls_types::Position {
                         line: 0,
                         character: 0,
                     },
-                    end: lsp_types::Position {
+                    end: ls_types::Position {
                         line: 0,
                         character: 0,
                     },

--- a/src/languageserver.rs
+++ b/src/languageserver.rs
@@ -9,8 +9,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use dashmap::DashMap;
 use tower_lsp::jsonrpc::{Error as LspError, Result};
-use tower_lsp::lsp_types::*;
-use tower_lsp::{LanguageServer, lsp_types};
+use tower_lsp::ls_types::*;
+use tower_lsp::{LanguageServer, ls_types};
 use tree_sitter::Parser;
 
 use self::config::Config;
@@ -97,7 +97,7 @@ impl Backend {
     }
 
     async fn publish_diagnostics(&self, uri: Uri, context: &str, lint_info: LintConfigInfo) {
-        let Ok(file_path) = uri.to_file_path() else {
+        let Some(file_path) = uri.to_file_path() else {
             tracing::error!("Cannot transport {uri:?} to file_path");
             self.client
                 .log_message(
@@ -200,7 +200,7 @@ impl LanguageServer for Backend {
                 .workspace_folders
                 .as_ref()
                 .and_then(|folders| folders.first())
-                .and_then(|folder| folder.uri.to_file_path().ok())
+                .and_then(|folder| folder.uri.to_file_path())
             {
                 let path = top_path.join("build").join("CMakeCache.txt");
                 if path.exists() {
@@ -241,7 +241,7 @@ impl LanguageServer for Backend {
             .workspace_folders
             .as_ref()
             .and_then(|folders| folders.first())
-            .and_then(|folder| folder.uri.to_file_path().ok())
+            .and_then(|folder| folder.uri.to_file_path())
         {
             self.root_path
                 .set(Some(project_root.to_path_buf()))
@@ -337,15 +337,15 @@ impl LanguageServer for Backend {
             watchers: vec![
                 FileSystemWatcher {
                     glob_pattern: GlobPattern::String("**/CMakeCache.txt".to_string()),
-                    kind: Some(lsp_types::WatchKind::all()),
+                    kind: Some(ls_types::WatchKind::all()),
                 },
                 FileSystemWatcher {
                     glob_pattern: GlobPattern::String("**/.cmake/api/v1/reply/*.json".to_string()),
-                    kind: Some(lsp_types::WatchKind::all()),
+                    kind: Some(ls_types::WatchKind::all()),
                 },
                 FileSystemWatcher {
                     glob_pattern: GlobPattern::String("**/CMakeLists.txt".to_string()),
-                    kind: Some(lsp_types::WatchKind::Create | lsp_types::WatchKind::Delete),
+                    kind: Some(ls_types::WatchKind::Create | ls_types::WatchKind::Delete),
                 },
             ],
         };
@@ -464,7 +464,7 @@ impl LanguageServer for Backend {
     async fn did_change_watched_files(&self, params: DidChangeWatchedFilesParams) {
         let mut has_cached_changed = false;
         for change in params.changes {
-            let Ok(file_path) = change.uri.to_file_path() else {
+            let Some(file_path) = change.uri.to_file_path() else {
                 continue;
             };
             let Some(file_name) = file_path
@@ -510,8 +510,8 @@ impl LanguageServer for Backend {
         self.documents.insert(uri.clone(), text.clone());
 
         let path = match uri.to_file_path() {
-            Ok(path) => path,
-            Err(_) => {
+            Some(path) => path,
+            None => {
                 tracing::error!("Can't create path from {}", uri.as_str());
                 return;
             }
@@ -520,7 +520,7 @@ impl LanguageServer for Backend {
         complete::update_cache(&path, &text).await;
         jump::update_cache(&path, &text).await;
         self.publish_diagnostics(
-            uri,
+            uri.clone(),
             &text,
             LintConfigInfo {
                 use_lint: self.init_info().enable_lint,
@@ -584,8 +584,8 @@ impl LanguageServer for Backend {
             return;
         };
         let file_path = match uri.to_file_path() {
-            Ok(file_path) => file_path,
-            Err(_) => {
+            Some(file_path) => file_path,
+            None => {
                 tracing::error!("Cannot get file_path from {}", uri.as_str());
                 return;
             }
@@ -674,8 +674,8 @@ impl LanguageServer for Backend {
         let location = input.text_document_position.position;
         let uri = input.text_document_position.text_document.uri;
         let file_path = match uri.to_file_path() {
-            Ok(file_path) => file_path,
-            Err(_) => {
+            Some(file_path) => file_path,
+            None => {
                 tracing::error!("Cannot get file_path from {}", uri.as_str());
                 return Err(LspError::internal_error());
             }
@@ -701,8 +701,8 @@ impl LanguageServer for Backend {
             return Ok(None);
         };
         let file_path = match uri.to_file_path() {
-            Ok(file_path) => file_path,
-            Err(_) => {
+            Some(file_path) => file_path,
+            None => {
                 tracing::error!("Cannot get file_path from {uri:?}");
                 return Err(LspError::internal_error());
             }
@@ -727,8 +727,8 @@ impl LanguageServer for Backend {
             return Ok(None);
         };
         let file_path = match uri.to_file_path() {
-            Ok(file_path) => file_path,
-            Err(_) => {
+            Some(file_path) => file_path,
+            None => {
                 tracing::error!("Cannot get file_path from {uri:?}");
                 return Err(LspError::internal_error());
             }
@@ -760,8 +760,8 @@ impl LanguageServer for Backend {
         let origin_selection_range = treehelper::get_position_range(location, tree.root_node());
 
         let file_path = match uri.to_file_path() {
-            Ok(file_path) => file_path,
-            Err(_) => {
+            Some(file_path) => file_path,
+            None => {
                 tracing::error!("Cannot get file_path from {uri:?}");
                 return Err(LspError::internal_error());
             }
@@ -822,8 +822,8 @@ impl LanguageServer for Backend {
     async fn document_link(&self, input: DocumentLinkParams) -> Result<Option<Vec<DocumentLink>>> {
         let uri = input.text_document.uri;
         let file_path = match uri.to_file_path() {
-            Ok(file_path) => file_path,
-            Err(_) => {
+            Some(file_path) => file_path,
+            None => {
                 tracing::error!("Cannot get file_path from {uri:?}");
                 return Err(LspError::internal_error());
             }

--- a/src/languageserver/test.rs
+++ b/src/languageserver/test.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 use tower::Service;
 use tower::util::ServiceExt;
 use tower_lsp::jsonrpc::Request;
-use tower_lsp::lsp_types::{
+use tower_lsp::ls_types::{
     CompletionParams, CompletionResponse, DidOpenTextDocumentParams, InitializeParams,
     InitializeResult, PartialResultParams, Position, SemanticTokensFullOptions,
     SemanticTokensLegend, SemanticTokensOptions, SemanticTokensServerCapabilities,

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ mod semantic_token;
 mod utils;
 use std::sync::OnceLock;
 
-use tower_lsp::lsp_types::Uri;
+use tower_lsp::ls_types::Uri;
 
 use crate::cli::{Cli, Command};
 use crate::formatting::format_file;

--- a/src/quick_fix.rs
+++ b/src/quick_fix.rs
@@ -1,7 +1,7 @@
 use std::sync::LazyLock;
 
 use regex::Regex;
-use tower_lsp::lsp_types::{
+use tower_lsp::ls_types::{
     CodeAction, CodeActionKind, CodeActionOrCommand, CodeActionResponse, Diagnostic,
     DocumentChanges, OneOf, OptionalVersionedTextDocumentIdentifier, Range, TextDocumentEdit,
     TextEdit, WorkspaceEdit,
@@ -17,7 +17,7 @@ pub fn lint_fix_action(
     context: &str,
     line: u32,
     diagnose: &Diagnostic,
-    uri: tower_lsp::lsp_types::Uri,
+    uri: tower_lsp::ls_types::Uri,
 ) -> Option<CodeActionResponse> {
     let caps = LINT_REGEX.captures(&diagnose.message)?;
     let longest = caps["max"].parse().unwrap();
@@ -34,7 +34,7 @@ fn sub_lint_fix_action(
     line: usize,
     diagnose: &Diagnostic,
     longest: usize,
-    uri: &tower_lsp::lsp_types::Uri,
+    uri: &tower_lsp::ls_types::Uri,
 ) -> Option<CodeActionResponse> {
     let argument_lists = get_argument_lists(source.as_bytes(), input, None);
     let argument_list = argument_lists.into_iter().find(|argument| {

--- a/src/rename.rs
+++ b/src/rename.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use dashmap::DashMap;
-use tower_lsp::lsp_types::{Location, Position, TextEdit, Uri, WorkspaceEdit};
+use tower_lsp::ls_types::{Location, Position, TextEdit, Uri, WorkspaceEdit};
 
 use crate::jump;
 

--- a/src/semantic_token.rs
+++ b/src/semantic_token.rs
@@ -1,9 +1,7 @@
 use std::sync::LazyLock;
 
 use tower_lsp::Client;
-use tower_lsp::lsp_types::{
-    SemanticToken, SemanticTokenType, SemanticTokens, SemanticTokensResult,
-};
+use tower_lsp::ls_types::{SemanticToken, SemanticTokenType, SemanticTokens, SemanticTokensResult};
 
 use crate::CMakeNodeKinds;
 use crate::consts::TREESITTER_CMAKE_LANGUAGE;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use std::sync::{LazyLock, Mutex};
 
 use serde::{Deserialize, Serialize};
-use tower_lsp::lsp_types::Uri;
+use tower_lsp::ls_types::Uri;
 
 pub use self::findpackage::*;
 use crate::fileapi;

--- a/src/utils/findpackage.rs
+++ b/src/utils/findpackage.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::LazyLock;
 
-use tower_lsp::lsp_types::Uri;
+use tower_lsp::ls_types::Uri;
 use tree_sitter::Point;
 
 pub use self::cmakepackage::*;

--- a/src/utils/query.rs
+++ b/src/utils/query.rs
@@ -1,6 +1,7 @@
 use tree_sitter::{Node, Query, QueryCursor, StreamingIterator};
 
-use crate::{CMakeNodeKinds, consts::TREESITTER_CMAKE_LANGUAGE};
+use crate::CMakeNodeKinds;
+use crate::consts::TREESITTER_CMAKE_LANGUAGE;
 
 const ARGUMENT_LIST_QUERY: &str = r"(
     (argument_list) @argument_list

--- a/src/utils/treehelper.rs
+++ b/src/utils/treehelper.rs
@@ -3,9 +3,9 @@ use std::iter::zip;
 use std::process::Command;
 use std::sync::LazyLock;
 
-use lsp_types::{Position, Range};
+use ls_types::{Position, Range};
 /// Some tools for treesitter  to lsp_types
-use tower_lsp::lsp_types;
+use tower_lsp::ls_types;
 use tree_sitter::{Node, Point};
 
 use crate::CMakeNodeKinds;
@@ -375,9 +375,8 @@ fn get_pos_type_inner<'a>(
 }
 #[cfg(test)]
 mod tests {
-    use crate::consts::TREESITTER_CMAKE_LANGUAGE;
-
     use super::*;
+    use crate::consts::TREESITTER_CMAKE_LANGUAGE;
     fn parse_tree(source: &str) -> tree_sitter::Tree {
         let mut parser = tree_sitter::Parser::new();
         parser.set_language(&TREESITTER_CMAKE_LANGUAGE).unwrap();


### PR DESCRIPTION
Reviewing the changes between neocmakelsp's fork and tower-lsp-server it seems mostly the same. This should provide a smoother way forward.

There are also plans to improve the `lsp_types` situation by using a code generator from the official LSP spec.