### PR TITLE
perf: remove a large copy in `get_version()` and reuse parser

### DIFF
--- a/src/utils/findpackage.rs
+++ b/src/utils/findpackage.rs
@@ -20,10 +20,9 @@ use self::packageunix as cmakepackage;
 use self::packagewin as cmakepackage;
 pub use self::vcpkg::*;
 use super::{CMakePackage, CMakePackageFrom, PackageType};
-use crate::utils::query;
 #[cfg(test)]
 use crate::consts::TREESITTER_CMAKE_LANGUAGE;
-
+use crate::utils::query;
 
 const LIBS: &[Cow<'_, str>] = &[
     Cow::Borrowed("lib"),
@@ -251,34 +250,25 @@ pub static CACHE_CMAKE_PACKAGES_WITHKEYS: LazyLock<HashMap<String, CMakePackage>
     LazyLock::new(get_cmake_packages_withkeys);
 
 fn get_version(source: &[u8], parser: &mut Parser) -> Option<String> {
-    let tree = match parser.parse(source, None) {
-        None => { return None; },
-        Some(t) => t
-    };
+    let tree = parser.parse(source, None)?;
     let commands = query::get_normal_commands(source, tree.root_node(), None);
 
-    for cmd in commands {
-        if !cmd.identifier.eq_ignore_ascii_case("set") {
-            continue;
-        }
+    let cmd = commands.iter().find(|node| {
+        node.identifier.eq_ignore_ascii_case("set")
+            && node
+                .first_arg
+                .is_some_and(|arg| arg.eq_ignore_ascii_case("PACKAGE_VERSION"))
+    })?;
 
-        let index_var = match cmd.args
-            .iter()
-            .position(|arg| arg.utf8_text(source).unwrap() == "PACKAGE_VERSION") {
-                None => { continue; },
-                Some(idx) => idx
-        };
-        if cmd.args.len() - 1 > index_var {
-            return Some(
-                cmd.args[index_var + 1].utf8_text(source)
-                    .unwrap()
-                    .trim_matches(|m| m == '"' || m == '\n')
-                    .to_string()
-            );
-        }
+    if cmd.args.len() == 1 {
+        return None;
     }
+    let version = cmd.args[1]
+        .utf8_text(source)
+        .ok()?
+        .trim_matches(|c| c == '"' || c == '\n' || c == ' ');
 
-    None
+    Some(version.to_owned())
 }
 
 #[cfg(unix)]
@@ -425,17 +415,32 @@ mod tests {
         parser.set_language(&TREESITTER_CMAKE_LANGUAGE).unwrap();
 
         let projectversion = "set(PACKAGE_VERSION 5.11)";
-        assert_eq!(get_version(projectversion.as_bytes(), &mut parser), Some("5.11".to_string()));
+        assert_eq!(
+            get_version(projectversion.as_bytes(), &mut parser),
+            Some("5.11".to_string())
+        );
         let projectversion = "SET(PACKAGE_VERSION  5.11   )";
-        assert_eq!(get_version(projectversion.as_bytes(), &mut parser), Some("5.11".to_string()));
+        assert_eq!(
+            get_version(projectversion.as_bytes(), &mut parser),
+            Some("5.11".to_string())
+        );
         let projectversion = "set(PACKAGE_VERSION \"1.3.14
 \")";
-        assert_eq!(get_version(projectversion.as_bytes(), &mut parser), Some("1.3.14".to_string()));
+        assert_eq!(
+            get_version(projectversion.as_bytes(), &mut parser),
+            Some("1.3.14".to_string())
+        );
         let projectversion = "set(PACKAGE_VERSION \"1.3.14
 
 \")";
-        assert_eq!(get_version(projectversion.as_bytes(), &mut parser), Some("1.3.14".to_string()));
+        assert_eq!(
+            get_version(projectversion.as_bytes(), &mut parser),
+            Some("1.3.14".to_string())
+        );
         let qmlversion = include_str!("../../assets_for_test/Qt5QmlConfigVersion.cmake");
-        assert_eq!(get_version(qmlversion.as_bytes(), &mut parser), Some("5.15.6".to_string()));
+        assert_eq!(
+            get_version(qmlversion.as_bytes(), &mut parser),
+            Some("5.15.6".to_string())
+        );
     }
 }

--- a/src/utils/findpackage.rs
+++ b/src/utils/findpackage.rs
@@ -11,7 +11,6 @@ use std::process::Command;
 use std::sync::LazyLock;
 
 use tower_lsp::lsp_types::Uri;
-use tree_sitter::Point;
 
 pub use self::cmakepackage::*;
 #[cfg(not(target_os = "windows"))]
@@ -21,6 +20,7 @@ use self::packagewin as cmakepackage;
 pub use self::vcpkg::*;
 use super::{CMakePackage, CMakePackageFrom, PackageType};
 use crate::CMakeNodeKinds;
+#[cfg(test)]
 use crate::consts::TREESITTER_CMAKE_LANGUAGE;
 
 const LIBS: &[Cow<'_, str>] = &[
@@ -248,65 +248,54 @@ pub static CACHE_CMAKE_PACKAGES: LazyLock<Vec<CMakePackage>> = LazyLock::new(get
 pub static CACHE_CMAKE_PACKAGES_WITHKEYS: LazyLock<HashMap<String, CMakePackage>> =
     LazyLock::new(get_cmake_packages_withkeys);
 
-fn string_from_two_valid_points(source: Vec<&str>, start: &Point, end: &Point) -> String {
-    if start.row == end.row {
-        return source[start.row][start.column..end.column].into();
-    }
-
-    let mut span = String::new();
-
-    span += &source[start.row][start.column..];
-    for row in source.iter().take(end.row).skip(start.row + 1) {
-        span += row;
-    }
-    span += &source[end.row][..end.column];
-
-    span
-}
-
-fn get_version(source: &str) -> Option<String> {
-    let newsource: Vec<&str> = source.lines().collect();
-    let mut parse = tree_sitter::Parser::new();
-    parse.set_language(&TREESITTER_CMAKE_LANGUAGE).unwrap();
-    let thetree = parse.parse(source, None);
-    let tree = thetree.unwrap();
-    let input = tree.root_node();
-    let mut course = input.walk();
-    for child in input.children(&mut course) {
+fn get_version(source: &str, parser: &mut tree_sitter::Parser) -> Option<String> {
+    let bytes = source.as_bytes();
+    let tree = parser.parse(source, None)?;
+    let root = tree.root_node();
+    let mut course = root.walk();
+    for child in root.children(&mut course) {
         if child.kind() == CMakeNodeKinds::NORMAL_COMMAND {
-            let h = child.start_position().row;
-            let ids = child.child(0).unwrap();
-            let x = ids.start_position().column;
-            let y = ids.end_position().column;
-            let name = &newsource[h][x..y];
-            if name == "set" || name == "SET" {
-                let argumentlist = child.child(2)?;
-                let id = argumentlist.child(0)?;
-                let version = argumentlist.child(1)?;
-                let h = id.start_position().row;
-                let x = id.start_position().column;
-                let y = id.end_position().column;
-                if x != y {
-                    let name = &newsource[h][x..y];
-                    if name == "PACKAGE_VERSION" {
-                        let version_string = string_from_two_valid_points(
-                            newsource,
-                            &version.start_position(),
-                            &version.end_position(),
-                        );
-                        return Some(
-                            version_string
-                                .trim_matches(|c| c == '"' || c == '\n' || c == ' ')
-                                .to_string(),
-                        );
-                    }
-                }
+            let cmd_name = child.child(0)?
+                .utf8_text(bytes)
+                .ok()
+                .unwrap_or("");
+            if !cmd_name.eq_ignore_ascii_case("set") {
+                continue;
+            }
+
+            let arg_list = match child.child(2) {
+                None => continue,
+                Some(arg_list) => arg_list
+            };
+            if arg_list.child_count() < 2 {
+                continue;
+            }
+
+            let var_name = arg_list.child(0)?
+                .utf8_text(bytes).ok()?;
+            let version_text = arg_list.child(1)?
+                .utf8_text(bytes).ok()?;
+            if var_name == "PACKAGE_VERSION" {
+                return Some(
+                    version_text
+                        .trim_matches(|c| c == '"' || c == '\n' || c == ' ')
+                        .to_string(),
+                );
             }
         }
     }
 
     None
 }
+
+/*
+fn get_version_old(source: &str) -> Option<String> {
+    let mut parser = tree_sitter::Parser::new();
+    parser.set_language(&TREESITTER_CMAKE_LANGUAGE).unwrap();
+
+    get_version(&source, &mut parser)
+}
+*/
 
 #[cfg(unix)]
 pub mod packagepkgconfig {
@@ -448,18 +437,37 @@ mod tests {
 
     #[test]
     fn test_version() {
+        /* Old Test
         let projectversion = "set(PACKAGE_VERSION 5.11)";
-        assert_eq!(get_version(projectversion), Some("5.11".to_string()));
+        assert_eq!(get_version_old(projectversion), Some("5.11".to_string()));
         let projectversion = "SET(PACKAGE_VERSION 5.11)";
-        assert_eq!(get_version(projectversion), Some("5.11".to_string()));
+        assert_eq!(get_version_old(projectversion), Some("5.11".to_string()));
         let projectversion = "set(PACKAGE_VERSION \"1.3.14
 \")";
-        assert_eq!(get_version(projectversion), Some("1.3.14".to_string()));
+        assert_eq!(get_version_old(projectversion), Some("1.3.14".to_string()));
         let projectversion = "set(PACKAGE_VERSION \"1.3.14
 
 \")";
-        assert_eq!(get_version(projectversion), Some("1.3.14".to_string()));
+        assert_eq!(get_version_old(projectversion), Some("1.3.14".to_string()));
         let qmlversion = include_str!("../../assets_for_test/Qt5QmlConfigVersion.cmake");
-        assert_eq!(get_version(qmlversion), Some("5.15.6".to_string()));
+        assert_eq!(get_version_old(qmlversion), Some("5.15.6".to_string()));
+        */
+        // New Test
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&TREESITTER_CMAKE_LANGUAGE).unwrap();
+
+        let projectversion = "set(PACKAGE_VERSION 5.11)";
+        assert_eq!(get_version(projectversion, &mut parser), Some("5.11".to_string()));
+        let projectversion = "SET(PACKAGE_VERSION 5.11)";
+        assert_eq!(get_version(projectversion, &mut parser), Some("5.11".to_string()));
+        let projectversion = "set(PACKAGE_VERSION \"1.3.14
+\")";
+        assert_eq!(get_version(projectversion, &mut parser), Some("1.3.14".to_string()));
+        let projectversion = "set(PACKAGE_VERSION \"1.3.14
+
+\")";
+        assert_eq!(get_version(projectversion, &mut parser), Some("1.3.14".to_string()));
+        let qmlversion = include_str!("../../assets_for_test/Qt5QmlConfigVersion.cmake");
+        assert_eq!(get_version(qmlversion, &mut parser), Some("5.15.6".to_string()));
     }
 }

--- a/src/utils/findpackage.rs
+++ b/src/utils/findpackage.rs
@@ -11,6 +11,7 @@ use std::process::Command;
 use std::sync::LazyLock;
 
 use tower_lsp::lsp_types::Uri;
+use tree_sitter::{Parser, Query, QueryCursor, StreamingIterator};
 
 pub use self::cmakepackage::*;
 #[cfg(not(target_os = "windows"))]
@@ -18,10 +19,10 @@ use self::packageunix as cmakepackage;
 #[cfg(target_os = "windows")]
 use self::packagewin as cmakepackage;
 pub use self::vcpkg::*;
-use super::{CMakePackage, CMakePackageFrom, PackageType};
+use super::{CMakePackage, CMakePackageFrom, PackageType, query::NORMAL_COMMAND_QUERY};
 use crate::CMakeNodeKinds;
-#[cfg(test)]
 use crate::consts::TREESITTER_CMAKE_LANGUAGE;
+
 
 const LIBS: &[Cow<'_, str>] = &[
     Cow::Borrowed("lib"),
@@ -248,54 +249,64 @@ pub static CACHE_CMAKE_PACKAGES: LazyLock<Vec<CMakePackage>> = LazyLock::new(get
 pub static CACHE_CMAKE_PACKAGES_WITHKEYS: LazyLock<HashMap<String, CMakePackage>> =
     LazyLock::new(get_cmake_packages_withkeys);
 
-fn get_version(source: &str, parser: &mut tree_sitter::Parser) -> Option<String> {
-    let bytes = source.as_bytes();
+fn get_version_cache(parser: &mut Parser) -> Query {
+    let query = Query::new(&TREESITTER_CMAKE_LANGUAGE, &NORMAL_COMMAND_QUERY).unwrap();
+    parser.set_language(&TREESITTER_CMAKE_LANGUAGE).unwrap();
+    query
+}
+
+fn get_version(source: &str, query: &Query, parser: &mut Parser) -> Option<String> {
+    let source = source.as_bytes();
+    if !source.windows(15).any(|win| win == b"PACKAGE_VERSION") {
+        return None;
+    }
     let tree = parser.parse(source, None)?;
-    let root = tree.root_node();
-    let mut course = root.walk();
-    for child in root.children(&mut course) {
-        if child.kind() == CMakeNodeKinds::NORMAL_COMMAND {
-            let cmd_name = child.child(0)?
-                .utf8_text(bytes)
-                .ok()
-                .unwrap_or("");
-            if !cmd_name.eq_ignore_ascii_case("set") {
-                continue;
-            }
-
-            let arg_list = match child.child(2) {
-                None => continue,
-                Some(arg_list) => arg_list
-            };
-            if arg_list.child_count() < 2 {
-                continue;
-            }
-
-            let var_name = arg_list.child(0)?
-                .utf8_text(bytes).ok()?;
-            let version_text = arg_list.child(1)?
-                .utf8_text(bytes).ok()?;
-            if var_name == "PACKAGE_VERSION" {
-                return Some(
-                    version_text
-                        .trim_matches(|c| c == '"' || c == '\n' || c == ' ')
-                        .to_string(),
-                );
+    let mut cursor_cmd = QueryCursor::new();
+    let mut matches_cmd = cursor_cmd.matches(&query, tree.root_node(), source);
+    while let Some(m) = matches_cmd.next() {
+        let node = m.nodes_for_capture_index(0).next().unwrap();
+        let Some(identifier) = node.child(0) else {
+            continue;
+        };
+        if identifier.kind() != CMakeNodeKinds::IDENTIFIER {
+            continue;
+        }
+        if !identifier.utf8_text(source).unwrap().eq_ignore_ascii_case("set") {
+            continue;
+        }
+        // NOTE: child 1 is "(", it is child 2 that argument_list
+        if let Some(arg_list) = node.child(2)
+            && arg_list.kind() == CMakeNodeKinds::ARGUMENT_LIST
+        {
+            let mut walk = arg_list.walk();
+            let mut ore = true;  // odd or even
+            let mut found_var = false;
+            for child in arg_list.children(&mut walk) {
+                if ore {
+                    let var = match child.utf8_text(source).ok() {
+                        None => { continue; },
+                        Some(v) => { v }
+                    };
+                    if var == "PACKAGE_VERSION" {
+                        found_var = true;
+                    }
+                } else {
+                    if found_var {
+                        return Some(
+                            child.utf8_text(source)
+                                .ok()?
+                                .trim_matches(|m| m == '"' || m == '\n')
+                                .to_string()
+                        );
+                    }
+                }
+                ore = !ore;
             }
         }
     }
 
     None
 }
-
-/*
-fn get_version_old(source: &str) -> Option<String> {
-    let mut parser = tree_sitter::Parser::new();
-    parser.set_language(&TREESITTER_CMAKE_LANGUAGE).unwrap();
-
-    get_version(&source, &mut parser)
-}
-*/
 
 #[cfg(unix)]
 pub mod packagepkgconfig {
@@ -437,37 +448,21 @@ mod tests {
 
     #[test]
     fn test_version() {
-        /* Old Test
-        let projectversion = "set(PACKAGE_VERSION 5.11)";
-        assert_eq!(get_version_old(projectversion), Some("5.11".to_string()));
-        let projectversion = "SET(PACKAGE_VERSION 5.11)";
-        assert_eq!(get_version_old(projectversion), Some("5.11".to_string()));
-        let projectversion = "set(PACKAGE_VERSION \"1.3.14
-\")";
-        assert_eq!(get_version_old(projectversion), Some("1.3.14".to_string()));
-        let projectversion = "set(PACKAGE_VERSION \"1.3.14
-
-\")";
-        assert_eq!(get_version_old(projectversion), Some("1.3.14".to_string()));
-        let qmlversion = include_str!("../../assets_for_test/Qt5QmlConfigVersion.cmake");
-        assert_eq!(get_version_old(qmlversion), Some("5.15.6".to_string()));
-        */
-        // New Test
         let mut parser = tree_sitter::Parser::new();
-        parser.set_language(&TREESITTER_CMAKE_LANGUAGE).unwrap();
+        let query = get_version_cache(&mut parser);
 
         let projectversion = "set(PACKAGE_VERSION 5.11)";
-        assert_eq!(get_version(projectversion, &mut parser), Some("5.11".to_string()));
-        let projectversion = "SET(PACKAGE_VERSION 5.11)";
-        assert_eq!(get_version(projectversion, &mut parser), Some("5.11".to_string()));
+        assert_eq!(get_version(projectversion, &query, &mut parser), Some("5.11".to_string()));
+        let projectversion = "SET(PACKAGE_VERSION  5.11   )";
+        assert_eq!(get_version(projectversion, &query, &mut parser), Some("5.11".to_string()));
         let projectversion = "set(PACKAGE_VERSION \"1.3.14
 \")";
-        assert_eq!(get_version(projectversion, &mut parser), Some("1.3.14".to_string()));
+        assert_eq!(get_version(projectversion, &query, &mut parser), Some("1.3.14".to_string()));
         let projectversion = "set(PACKAGE_VERSION \"1.3.14
 
 \")";
-        assert_eq!(get_version(projectversion, &mut parser), Some("1.3.14".to_string()));
+        assert_eq!(get_version(projectversion, &query, &mut parser), Some("1.3.14".to_string()));
         let qmlversion = include_str!("../../assets_for_test/Qt5QmlConfigVersion.cmake");
-        assert_eq!(get_version(qmlversion, &mut parser), Some("5.15.6".to_string()));
+        assert_eq!(get_version(qmlversion, &query, &mut parser), Some("5.15.6".to_string()));
     }
 }

--- a/src/utils/findpackage.rs
+++ b/src/utils/findpackage.rs
@@ -11,6 +11,7 @@ use std::process::Command;
 use std::sync::LazyLock;
 
 use tower_lsp::lsp_types::Uri;
+use tree_sitter::Parser;
 
 pub use self::cmakepackage::*;
 #[cfg(not(target_os = "windows"))]
@@ -19,9 +20,10 @@ use self::packageunix as cmakepackage;
 use self::packagewin as cmakepackage;
 pub use self::vcpkg::*;
 use super::{CMakePackage, CMakePackageFrom, PackageType};
-use crate::CMakeNodeKinds;
+use crate::utils::query;
 #[cfg(test)]
 use crate::consts::TREESITTER_CMAKE_LANGUAGE;
+
 
 const LIBS: &[Cow<'_, str>] = &[
     Cow::Borrowed("lib"),
@@ -248,54 +250,34 @@ pub static CACHE_CMAKE_PACKAGES: LazyLock<Vec<CMakePackage>> = LazyLock::new(get
 pub static CACHE_CMAKE_PACKAGES_WITHKEYS: LazyLock<HashMap<String, CMakePackage>> =
     LazyLock::new(get_cmake_packages_withkeys);
 
-fn get_version(source: &str, parser: &mut tree_sitter::Parser) -> Option<String> {
-    let bytes = source.as_bytes();
+fn get_version(source: &[u8], parser: &mut Parser) -> Option<String> {
     let tree = parser.parse(source, None)?;
-    let root = tree.root_node();
-    let mut course = root.walk();
-    for child in root.children(&mut course) {
-        if child.kind() == CMakeNodeKinds::NORMAL_COMMAND {
-            let cmd_name = child.child(0)?
-                .utf8_text(bytes)
-                .ok()
-                .unwrap_or("");
-            if !cmd_name.eq_ignore_ascii_case("set") {
-                continue;
-            }
+    let commands = query::get_normal_commands(source, tree.root_node(), None);
 
-            let arg_list = match child.child(2) {
-                None => continue,
-                Some(arg_list) => arg_list
-            };
-            if arg_list.child_count() < 2 {
-                continue;
-            }
+    for cmd in commands {
+        if cmd.args.len() < 2 {
+            continue;
+        }
+        if !cmd.identifier.eq_ignore_ascii_case("set") {
+            continue;
+        }
 
-            let var_name = arg_list.child(0)?
-                .utf8_text(bytes).ok()?;
-            let version_text = arg_list.child(1)?
-                .utf8_text(bytes).ok()?;
-            if var_name == "PACKAGE_VERSION" {
+        let mut found_pkg_ver = false;
+        for arg in cmd.args {
+            let name = arg.utf8_text(source).unwrap();
+            if found_pkg_ver {
                 return Some(
-                    version_text
-                        .trim_matches(|c| c == '"' || c == '\n' || c == ' ')
-                        .to_string(),
+                    name.trim_matches(|m| m == '"' || m == '\n')
+                        .to_string()
                 );
+            } else if name == "PACKAGE_VERSION" {
+                found_pkg_ver = true;
             }
         }
     }
 
     None
 }
-
-/*
-fn get_version_old(source: &str) -> Option<String> {
-    let mut parser = tree_sitter::Parser::new();
-    parser.set_language(&TREESITTER_CMAKE_LANGUAGE).unwrap();
-
-    get_version(&source, &mut parser)
-}
-*/
 
 #[cfg(unix)]
 pub mod packagepkgconfig {
@@ -437,37 +419,21 @@ mod tests {
 
     #[test]
     fn test_version() {
-        /* Old Test
-        let projectversion = "set(PACKAGE_VERSION 5.11)";
-        assert_eq!(get_version_old(projectversion), Some("5.11".to_string()));
-        let projectversion = "SET(PACKAGE_VERSION 5.11)";
-        assert_eq!(get_version_old(projectversion), Some("5.11".to_string()));
-        let projectversion = "set(PACKAGE_VERSION \"1.3.14
-\")";
-        assert_eq!(get_version_old(projectversion), Some("1.3.14".to_string()));
-        let projectversion = "set(PACKAGE_VERSION \"1.3.14
-
-\")";
-        assert_eq!(get_version_old(projectversion), Some("1.3.14".to_string()));
-        let qmlversion = include_str!("../../assets_for_test/Qt5QmlConfigVersion.cmake");
-        assert_eq!(get_version_old(qmlversion), Some("5.15.6".to_string()));
-        */
-        // New Test
         let mut parser = tree_sitter::Parser::new();
         parser.set_language(&TREESITTER_CMAKE_LANGUAGE).unwrap();
 
         let projectversion = "set(PACKAGE_VERSION 5.11)";
-        assert_eq!(get_version(projectversion, &mut parser), Some("5.11".to_string()));
-        let projectversion = "SET(PACKAGE_VERSION 5.11)";
-        assert_eq!(get_version(projectversion, &mut parser), Some("5.11".to_string()));
+        assert_eq!(get_version(projectversion.as_bytes(), &mut parser), Some("5.11".to_string()));
+        let projectversion = "SET(PACKAGE_VERSION  5.11   )";
+        assert_eq!(get_version(projectversion.as_bytes(), &mut parser), Some("5.11".to_string()));
         let projectversion = "set(PACKAGE_VERSION \"1.3.14
 \")";
-        assert_eq!(get_version(projectversion, &mut parser), Some("1.3.14".to_string()));
+        assert_eq!(get_version(projectversion.as_bytes(), &mut parser), Some("1.3.14".to_string()));
         let projectversion = "set(PACKAGE_VERSION \"1.3.14
 
 \")";
-        assert_eq!(get_version(projectversion, &mut parser), Some("1.3.14".to_string()));
+        assert_eq!(get_version(projectversion.as_bytes(), &mut parser), Some("1.3.14".to_string()));
         let qmlversion = include_str!("../../assets_for_test/Qt5QmlConfigVersion.cmake");
-        assert_eq!(get_version(qmlversion, &mut parser), Some("5.15.6".to_string()));
+        assert_eq!(get_version(qmlversion.as_bytes(), &mut parser), Some("5.15.6".to_string()));
     }
 }

--- a/src/utils/findpackage.rs
+++ b/src/utils/findpackage.rs
@@ -11,7 +11,6 @@ use std::process::Command;
 use std::sync::LazyLock;
 
 use tower_lsp::lsp_types::Uri;
-use tree_sitter::{Parser, Query, QueryCursor, StreamingIterator};
 
 pub use self::cmakepackage::*;
 #[cfg(not(target_os = "windows"))]
@@ -19,10 +18,10 @@ use self::packageunix as cmakepackage;
 #[cfg(target_os = "windows")]
 use self::packagewin as cmakepackage;
 pub use self::vcpkg::*;
-use super::{CMakePackage, CMakePackageFrom, PackageType, query::NORMAL_COMMAND_QUERY};
+use super::{CMakePackage, CMakePackageFrom, PackageType};
 use crate::CMakeNodeKinds;
+#[cfg(test)]
 use crate::consts::TREESITTER_CMAKE_LANGUAGE;
-
 
 const LIBS: &[Cow<'_, str>] = &[
     Cow::Borrowed("lib"),
@@ -249,64 +248,54 @@ pub static CACHE_CMAKE_PACKAGES: LazyLock<Vec<CMakePackage>> = LazyLock::new(get
 pub static CACHE_CMAKE_PACKAGES_WITHKEYS: LazyLock<HashMap<String, CMakePackage>> =
     LazyLock::new(get_cmake_packages_withkeys);
 
-fn get_version_cache(parser: &mut Parser) -> Query {
-    let query = Query::new(&TREESITTER_CMAKE_LANGUAGE, &NORMAL_COMMAND_QUERY).unwrap();
-    parser.set_language(&TREESITTER_CMAKE_LANGUAGE).unwrap();
-    query
-}
-
-fn get_version(source: &str, query: &Query, parser: &mut Parser) -> Option<String> {
-    let source = source.as_bytes();
-    if !source.windows(15).any(|win| win == b"PACKAGE_VERSION") {
-        return None;
-    }
+fn get_version(source: &str, parser: &mut tree_sitter::Parser) -> Option<String> {
+    let bytes = source.as_bytes();
     let tree = parser.parse(source, None)?;
-    let mut cursor_cmd = QueryCursor::new();
-    let mut matches_cmd = cursor_cmd.matches(&query, tree.root_node(), source);
-    while let Some(m) = matches_cmd.next() {
-        let node = m.nodes_for_capture_index(0).next().unwrap();
-        let Some(identifier) = node.child(0) else {
-            continue;
-        };
-        if identifier.kind() != CMakeNodeKinds::IDENTIFIER {
-            continue;
-        }
-        if !identifier.utf8_text(source).unwrap().eq_ignore_ascii_case("set") {
-            continue;
-        }
-        // NOTE: child 1 is "(", it is child 2 that argument_list
-        if let Some(arg_list) = node.child(2)
-            && arg_list.kind() == CMakeNodeKinds::ARGUMENT_LIST
-        {
-            let mut walk = arg_list.walk();
-            let mut ore = true;  // odd or even
-            let mut found_var = false;
-            for child in arg_list.children(&mut walk) {
-                if ore {
-                    let var = match child.utf8_text(source).ok() {
-                        None => { continue; },
-                        Some(v) => { v }
-                    };
-                    if var == "PACKAGE_VERSION" {
-                        found_var = true;
-                    }
-                } else {
-                    if found_var {
-                        return Some(
-                            child.utf8_text(source)
-                                .ok()?
-                                .trim_matches(|m| m == '"' || m == '\n')
-                                .to_string()
-                        );
-                    }
-                }
-                ore = !ore;
+    let root = tree.root_node();
+    let mut course = root.walk();
+    for child in root.children(&mut course) {
+        if child.kind() == CMakeNodeKinds::NORMAL_COMMAND {
+            let cmd_name = child.child(0)?
+                .utf8_text(bytes)
+                .ok()
+                .unwrap_or("");
+            if !cmd_name.eq_ignore_ascii_case("set") {
+                continue;
+            }
+
+            let arg_list = match child.child(2) {
+                None => continue,
+                Some(arg_list) => arg_list
+            };
+            if arg_list.child_count() < 2 {
+                continue;
+            }
+
+            let var_name = arg_list.child(0)?
+                .utf8_text(bytes).ok()?;
+            let version_text = arg_list.child(1)?
+                .utf8_text(bytes).ok()?;
+            if var_name == "PACKAGE_VERSION" {
+                return Some(
+                    version_text
+                        .trim_matches(|c| c == '"' || c == '\n' || c == ' ')
+                        .to_string(),
+                );
             }
         }
     }
 
     None
 }
+
+/*
+fn get_version_old(source: &str) -> Option<String> {
+    let mut parser = tree_sitter::Parser::new();
+    parser.set_language(&TREESITTER_CMAKE_LANGUAGE).unwrap();
+
+    get_version(&source, &mut parser)
+}
+*/
 
 #[cfg(unix)]
 pub mod packagepkgconfig {
@@ -448,21 +437,37 @@ mod tests {
 
     #[test]
     fn test_version() {
+        /* Old Test
+        let projectversion = "set(PACKAGE_VERSION 5.11)";
+        assert_eq!(get_version_old(projectversion), Some("5.11".to_string()));
+        let projectversion = "SET(PACKAGE_VERSION 5.11)";
+        assert_eq!(get_version_old(projectversion), Some("5.11".to_string()));
+        let projectversion = "set(PACKAGE_VERSION \"1.3.14
+\")";
+        assert_eq!(get_version_old(projectversion), Some("1.3.14".to_string()));
+        let projectversion = "set(PACKAGE_VERSION \"1.3.14
+
+\")";
+        assert_eq!(get_version_old(projectversion), Some("1.3.14".to_string()));
+        let qmlversion = include_str!("../../assets_for_test/Qt5QmlConfigVersion.cmake");
+        assert_eq!(get_version_old(qmlversion), Some("5.15.6".to_string()));
+        */
+        // New Test
         let mut parser = tree_sitter::Parser::new();
-        let query = get_version_cache(&mut parser);
+        parser.set_language(&TREESITTER_CMAKE_LANGUAGE).unwrap();
 
         let projectversion = "set(PACKAGE_VERSION 5.11)";
-        assert_eq!(get_version(projectversion, &query, &mut parser), Some("5.11".to_string()));
-        let projectversion = "SET(PACKAGE_VERSION  5.11   )";
-        assert_eq!(get_version(projectversion, &query, &mut parser), Some("5.11".to_string()));
+        assert_eq!(get_version(projectversion, &mut parser), Some("5.11".to_string()));
+        let projectversion = "SET(PACKAGE_VERSION 5.11)";
+        assert_eq!(get_version(projectversion, &mut parser), Some("5.11".to_string()));
         let projectversion = "set(PACKAGE_VERSION \"1.3.14
 \")";
-        assert_eq!(get_version(projectversion, &query, &mut parser), Some("1.3.14".to_string()));
+        assert_eq!(get_version(projectversion, &mut parser), Some("1.3.14".to_string()));
         let projectversion = "set(PACKAGE_VERSION \"1.3.14
 
 \")";
-        assert_eq!(get_version(projectversion, &query, &mut parser), Some("1.3.14".to_string()));
+        assert_eq!(get_version(projectversion, &mut parser), Some("1.3.14".to_string()));
         let qmlversion = include_str!("../../assets_for_test/Qt5QmlConfigVersion.cmake");
-        assert_eq!(get_version(qmlversion, &query, &mut parser), Some("5.15.6".to_string()));
+        assert_eq!(get_version(qmlversion, &mut parser), Some("5.15.6".to_string()));
     }
 }

--- a/src/utils/findpackage.rs
+++ b/src/utils/findpackage.rs
@@ -251,28 +251,30 @@ pub static CACHE_CMAKE_PACKAGES_WITHKEYS: LazyLock<HashMap<String, CMakePackage>
     LazyLock::new(get_cmake_packages_withkeys);
 
 fn get_version(source: &[u8], parser: &mut Parser) -> Option<String> {
-    let tree = parser.parse(source, None)?;
+    let tree = match parser.parse(source, None) {
+        None => { return None; },
+        Some(t) => t
+    };
     let commands = query::get_normal_commands(source, tree.root_node(), None);
 
     for cmd in commands {
-        if cmd.args.len() < 2 {
-            continue;
-        }
         if !cmd.identifier.eq_ignore_ascii_case("set") {
             continue;
         }
 
-        let mut found_pkg_ver = false;
-        for arg in cmd.args {
-            let name = arg.utf8_text(source).unwrap();
-            if found_pkg_ver {
-                return Some(
-                    name.trim_matches(|m| m == '"' || m == '\n')
-                        .to_string()
-                );
-            } else if name == "PACKAGE_VERSION" {
-                found_pkg_ver = true;
-            }
+        let index_var = match cmd.args
+            .iter()
+            .position(|arg| arg.utf8_text(source).unwrap() == "PACKAGE_VERSION") {
+                None => { continue; },
+                Some(idx) => idx
+        };
+        if cmd.args.len() - 1 > index_var {
+            return Some(
+                cmd.args[index_var + 1].utf8_text(source)
+                    .unwrap()
+                    .trim_matches(|m| m == '"' || m == '\n')
+                    .to_string()
+            );
         }
     }
 

--- a/src/utils/findpackage/packageunix.rs
+++ b/src/utils/findpackage/packageunix.rs
@@ -5,7 +5,7 @@ use std::sync::LazyLock;
 
 use super::{
     CMAKECONFIG, CMAKECONFIGVERSION, CMAKEREGEX, SPECIAL_PACKAGE_PATTERN, get_available_libs,
-    get_cmake_message, get_version, handle_config_package,
+    get_cmake_message, handle_config_package, get_version
 };
 use crate::Uri;
 use crate::utils::{CMakePackage, CMakePackageFrom, PackageType};
@@ -45,7 +45,7 @@ pub(super) fn get_cmake_message_with_prefixes(
                 if CMAKECONFIGVERSION.is_match(file.to_str().unwrap())
                     && let Ok(context) = fs::read_to_string(&file)
                 {
-                    version = get_version(&context, &mut parser);
+                    version = get_version(&context.as_bytes(), &mut parser);
                 }
             }
             if !ispackage {
@@ -108,7 +108,7 @@ pub(super) fn get_cmake_message_with_prefixes(
                                 if CMAKECONFIGVERSION.is_match(filename)
                                     && let Ok(context) = fs::read_to_string(&filepath)
                                 {
-                                    version = get_version(&context, &mut parser);
+                                    version = get_version(&context.as_bytes(), &mut parser);
                                 }
                                 tojump.push(filepath);
                             }

--- a/src/utils/findpackage/packageunix.rs
+++ b/src/utils/findpackage/packageunix.rs
@@ -5,11 +5,11 @@ use std::sync::LazyLock;
 
 use super::{
     CMAKECONFIG, CMAKECONFIGVERSION, CMAKEREGEX, SPECIAL_PACKAGE_PATTERN, get_available_libs,
-    get_cmake_message, handle_config_package, get_version
+    get_cmake_message, get_version, handle_config_package,
 };
 use crate::Uri;
-use crate::utils::{CMakePackage, CMakePackageFrom, PackageType};
 use crate::consts::TREESITTER_CMAKE_LANGUAGE;
+use crate::utils::{CMakePackage, CMakePackageFrom, PackageType};
 
 pub(super) fn get_env_prefix() -> Option<String> {
     if cfg!(target_os = "android") {
@@ -45,7 +45,7 @@ pub(super) fn get_cmake_message_with_prefixes(
                 if CMAKECONFIGVERSION.is_match(file.to_str().unwrap())
                     && let Ok(context) = fs::read_to_string(&file)
                 {
-                    version = get_version(&context.as_bytes(), &mut parser);
+                    version = get_version(context.as_bytes(), &mut parser);
                 }
             }
             if !ispackage {
@@ -108,7 +108,7 @@ pub(super) fn get_cmake_message_with_prefixes(
                                 if CMAKECONFIGVERSION.is_match(filename)
                                     && let Ok(context) = fs::read_to_string(&filepath)
                                 {
-                                    version = get_version(&context.as_bytes(), &mut parser);
+                                    version = get_version(context.as_bytes(), &mut parser);
                                 }
                                 tojump.push(filepath);
                             }

--- a/src/utils/findpackage/packageunix.rs
+++ b/src/utils/findpackage/packageunix.rs
@@ -9,6 +9,7 @@ use super::{
 };
 use crate::Uri;
 use crate::utils::{CMakePackage, CMakePackageFrom, PackageType};
+use crate::consts::TREESITTER_CMAKE_LANGUAGE;
 
 pub(super) fn get_env_prefix() -> Option<String> {
     if cfg!(target_os = "android") {
@@ -22,6 +23,9 @@ pub(super) fn get_cmake_message_with_prefixes(
     prefixes: &Vec<String>,
 ) -> HashMap<String, CMakePackage> {
     let mut packages: HashMap<String, CMakePackage> = HashMap::new();
+    let mut parser = tree_sitter::Parser::new();
+    parser.set_language(&TREESITTER_CMAKE_LANGUAGE).unwrap();
+
     for prefix in prefixes {
         let Ok(paths) = glob::glob(&format!("{prefix}/share/*/cmake/")) else {
             continue;
@@ -41,7 +45,7 @@ pub(super) fn get_cmake_message_with_prefixes(
                 if CMAKECONFIGVERSION.is_match(file.to_str().unwrap())
                     && let Ok(context) = fs::read_to_string(&file)
                 {
-                    version = get_version(&context);
+                    version = get_version(&context, &mut parser);
                 }
             }
             if !ispackage {
@@ -104,7 +108,7 @@ pub(super) fn get_cmake_message_with_prefixes(
                                 if CMAKECONFIGVERSION.is_match(filename)
                                     && let Ok(context) = fs::read_to_string(&filepath)
                                 {
-                                    version = get_version(&context);
+                                    version = get_version(&context, &mut parser);
                                 }
                                 tojump.push(filepath);
                             }

--- a/src/utils/findpackage/packageunix.rs
+++ b/src/utils/findpackage/packageunix.rs
@@ -5,7 +5,7 @@ use std::sync::LazyLock;
 
 use super::{
     CMAKECONFIG, CMAKECONFIGVERSION, CMAKEREGEX, SPECIAL_PACKAGE_PATTERN, get_available_libs,
-    get_cmake_message, handle_config_package, get_version, get_version_cache
+    get_cmake_message, get_version, handle_config_package,
 };
 use crate::Uri;
 use crate::utils::{CMakePackage, CMakePackageFrom, PackageType};
@@ -24,7 +24,6 @@ pub(super) fn get_cmake_message_with_prefixes(
 ) -> HashMap<String, CMakePackage> {
     let mut packages: HashMap<String, CMakePackage> = HashMap::new();
     let mut parser = tree_sitter::Parser::new();
-    let query = get_version_cache(&mut parser);
     parser.set_language(&TREESITTER_CMAKE_LANGUAGE).unwrap();
 
     for prefix in prefixes {
@@ -46,7 +45,7 @@ pub(super) fn get_cmake_message_with_prefixes(
                 if CMAKECONFIGVERSION.is_match(file.to_str().unwrap())
                     && let Ok(context) = fs::read_to_string(&file)
                 {
-                    version = get_version(&context, &query, &mut parser);
+                    version = get_version(&context, &mut parser);
                 }
             }
             if !ispackage {
@@ -109,7 +108,7 @@ pub(super) fn get_cmake_message_with_prefixes(
                                 if CMAKECONFIGVERSION.is_match(filename)
                                     && let Ok(context) = fs::read_to_string(&filepath)
                                 {
-                                    version = get_version(&context, &query, &mut parser);
+                                    version = get_version(&context, &mut parser);
                                 }
                                 tojump.push(filepath);
                             }

--- a/src/utils/findpackage/packageunix.rs
+++ b/src/utils/findpackage/packageunix.rs
@@ -5,7 +5,7 @@ use std::sync::LazyLock;
 
 use super::{
     CMAKECONFIG, CMAKECONFIGVERSION, CMAKEREGEX, SPECIAL_PACKAGE_PATTERN, get_available_libs,
-    get_cmake_message, get_version, handle_config_package,
+    get_cmake_message, handle_config_package, get_version, get_version_cache
 };
 use crate::Uri;
 use crate::utils::{CMakePackage, CMakePackageFrom, PackageType};
@@ -24,6 +24,7 @@ pub(super) fn get_cmake_message_with_prefixes(
 ) -> HashMap<String, CMakePackage> {
     let mut packages: HashMap<String, CMakePackage> = HashMap::new();
     let mut parser = tree_sitter::Parser::new();
+    let query = get_version_cache(&mut parser);
     parser.set_language(&TREESITTER_CMAKE_LANGUAGE).unwrap();
 
     for prefix in prefixes {
@@ -45,7 +46,7 @@ pub(super) fn get_cmake_message_with_prefixes(
                 if CMAKECONFIGVERSION.is_match(file.to_str().unwrap())
                     && let Ok(context) = fs::read_to_string(&file)
                 {
-                    version = get_version(&context, &mut parser);
+                    version = get_version(&context, &query, &mut parser);
                 }
             }
             if !ispackage {
@@ -108,7 +109,7 @@ pub(super) fn get_cmake_message_with_prefixes(
                                 if CMAKECONFIGVERSION.is_match(filename)
                                     && let Ok(context) = fs::read_to_string(&filepath)
                                 {
-                                    version = get_version(&context, &mut parser);
+                                    version = get_version(&context, &query, &mut parser);
                                 }
                                 tojump.push(filepath);
                             }

--- a/src/utils/findpackage/packagewin.rs
+++ b/src/utils/findpackage/packagewin.rs
@@ -5,11 +5,10 @@ use std::sync::LazyLock;
 
 use super::{
     CMAKECONFIG, CMAKECONFIGVERSION, CMAKEREGEX, SPECIAL_PACKAGE_PATTERN, get_available_libs,
-    get_cmake_message, get_version, get_version_cache, handle_config_package
+    get_cmake_message, get_version, handle_config_package,
 };
 use crate::Uri;
 use crate::utils::{CMakePackage, CMakePackageFrom, PackageType};
-use crate::consts::TREESITTER_CMAKE_LANGUAGE;
 
 pub static CMAKE_PACKAGES: LazyLock<Vec<CMakePackage>> =
     LazyLock::new(|| get_cmake_message().into_values().collect());
@@ -33,10 +32,6 @@ pub(super) fn get_cmake_message_with_prefixes(
     prefixes: &Vec<String>,
 ) -> HashMap<String, CMakePackage> {
     let mut packages: HashMap<String, CMakePackage> = HashMap::new();
-    let mut parser = tree_sitter::Parser::new();
-    let query = get_version_cache(&mut parser);
-    parser.set_language(&TREESITTER_CMAKE_LANGUAGE).unwrap();
-
     for prefix in prefixes {
         let Ok(paths) = glob::glob(&format!("{prefix}/share/*/cmake/")) else {
             continue;
@@ -56,7 +51,7 @@ pub(super) fn get_cmake_message_with_prefixes(
                 if CMAKECONFIGVERSION.is_match(f.to_str().unwrap())
                     && let Ok(context) = fs::read_to_string(&f)
                 {
-                    version = get_version(&context, &query, &mut parser);
+                    version = get_version(&context);
                 }
             }
 
@@ -122,7 +117,7 @@ pub(super) fn get_cmake_message_with_prefixes(
                                 if CMAKECONFIGVERSION.is_match(filename)
                                     && let Ok(context) = fs::read_to_string(&filepath)
                                 {
-                                    version = get_version(&context, &query, &mut parser);
+                                    version = get_version(&context);
                                 }
                             }
                         }

--- a/src/utils/findpackage/packagewin.rs
+++ b/src/utils/findpackage/packagewin.rs
@@ -5,10 +5,11 @@ use std::sync::LazyLock;
 
 use super::{
     CMAKECONFIG, CMAKECONFIGVERSION, CMAKEREGEX, SPECIAL_PACKAGE_PATTERN, get_available_libs,
-    get_cmake_message, get_version, handle_config_package,
+    get_cmake_message, get_version, get_version_cache, handle_config_package
 };
 use crate::Uri;
 use crate::utils::{CMakePackage, CMakePackageFrom, PackageType};
+use crate::consts::TREESITTER_CMAKE_LANGUAGE;
 
 pub static CMAKE_PACKAGES: LazyLock<Vec<CMakePackage>> =
     LazyLock::new(|| get_cmake_message().into_values().collect());
@@ -32,6 +33,10 @@ pub(super) fn get_cmake_message_with_prefixes(
     prefixes: &Vec<String>,
 ) -> HashMap<String, CMakePackage> {
     let mut packages: HashMap<String, CMakePackage> = HashMap::new();
+    let mut parser = tree_sitter::Parser::new();
+    let query = get_version_cache(&mut parser);
+    parser.set_language(&TREESITTER_CMAKE_LANGUAGE).unwrap();
+
     for prefix in prefixes {
         let Ok(paths) = glob::glob(&format!("{prefix}/share/*/cmake/")) else {
             continue;
@@ -51,7 +56,7 @@ pub(super) fn get_cmake_message_with_prefixes(
                 if CMAKECONFIGVERSION.is_match(f.to_str().unwrap())
                     && let Ok(context) = fs::read_to_string(&f)
                 {
-                    version = get_version(&context);
+                    version = get_version(&context, &query, &mut parser);
                 }
             }
 
@@ -117,7 +122,7 @@ pub(super) fn get_cmake_message_with_prefixes(
                                 if CMAKECONFIGVERSION.is_match(filename)
                                     && let Ok(context) = fs::read_to_string(&filepath)
                                 {
-                                    version = get_version(&context);
+                                    version = get_version(&context, &query, &mut parser);
                                 }
                             }
                         }

--- a/src/utils/findpackage/packagewin.rs
+++ b/src/utils/findpackage/packagewin.rs
@@ -5,10 +5,11 @@ use std::sync::LazyLock;
 
 use super::{
     CMAKECONFIG, CMAKECONFIGVERSION, CMAKEREGEX, SPECIAL_PACKAGE_PATTERN, get_available_libs,
-    get_cmake_message, get_version, handle_config_package,
+    get_cmake_message, get_version, handle_config_package
 };
 use crate::Uri;
 use crate::utils::{CMakePackage, CMakePackageFrom, PackageType};
+use crate::consts::TREESITTER_CMAKE_LANGUAGE;
 
 pub static CMAKE_PACKAGES: LazyLock<Vec<CMakePackage>> =
     LazyLock::new(|| get_cmake_message().into_values().collect());
@@ -32,6 +33,9 @@ pub(super) fn get_cmake_message_with_prefixes(
     prefixes: &Vec<String>,
 ) -> HashMap<String, CMakePackage> {
     let mut packages: HashMap<String, CMakePackage> = HashMap::new();
+    let mut parser = tree_sitter::Parser::new();
+    parser.set_language(&TREESITTER_CMAKE_LANGUAGE).unwrap();
+
     for prefix in prefixes {
         let Ok(paths) = glob::glob(&format!("{prefix}/share/*/cmake/")) else {
             continue;
@@ -51,7 +55,7 @@ pub(super) fn get_cmake_message_with_prefixes(
                 if CMAKECONFIGVERSION.is_match(f.to_str().unwrap())
                     && let Ok(context) = fs::read_to_string(&f)
                 {
-                    version = get_version(&context);
+                    version = get_version(&context.as_bytes(), &mut parser);
                 }
             }
 
@@ -117,7 +121,7 @@ pub(super) fn get_cmake_message_with_prefixes(
                                 if CMAKECONFIGVERSION.is_match(filename)
                                     && let Ok(context) = fs::read_to_string(&filepath)
                                 {
-                                    version = get_version(&context);
+                                    version = get_version(&context.as_bytes(), &mut parser);
                                 }
                             }
                         }

--- a/src/utils/findpackage/packagewin.rs
+++ b/src/utils/findpackage/packagewin.rs
@@ -5,11 +5,11 @@ use std::sync::LazyLock;
 
 use super::{
     CMAKECONFIG, CMAKECONFIGVERSION, CMAKEREGEX, SPECIAL_PACKAGE_PATTERN, get_available_libs,
-    get_cmake_message, get_version, handle_config_package
+    get_cmake_message, get_version, handle_config_package,
 };
 use crate::Uri;
-use crate::utils::{CMakePackage, CMakePackageFrom, PackageType};
 use crate::consts::TREESITTER_CMAKE_LANGUAGE;
+use crate::utils::{CMakePackage, CMakePackageFrom, PackageType};
 
 pub static CMAKE_PACKAGES: LazyLock<Vec<CMakePackage>> =
     LazyLock::new(|| get_cmake_message().into_values().collect());

--- a/src/utils/findpackage/vcpkg.rs
+++ b/src/utils/findpackage/vcpkg.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, LazyLock, Mutex};
 
 use super::{
     CMAKECONFIG, CMAKECONFIGVERSION, CMAKEREGEX, SPECIAL_PACKAGE_PATTERN, get_version,
-    handle_config_package,
+    handle_config_package
 };
 use crate::Uri;
 use crate::utils::{CMakePackage, CMakePackageFrom, PackageType};
@@ -73,7 +73,7 @@ fn get_cmake_message() -> HashMap<String, CMakePackage> {
                 if CMAKECONFIGVERSION.is_match(file.to_str().unwrap())
                     && let Ok(context) = fs::read_to_string(&file)
                 {
-                    version = get_version(&context, &mut parser);
+                    version = get_version(&context.as_bytes(), &mut parser);
                 }
             }
 
@@ -137,7 +137,7 @@ fn get_cmake_message() -> HashMap<String, CMakePackage> {
                                 if CMAKECONFIGVERSION.is_match(filename)
                                     && let Ok(context) = fs::read_to_string(&filepath)
                                 {
-                                    version = get_version(&context, &mut parser);
+                                    version = get_version(&context.as_bytes(), &mut parser);
                                 }
                             }
                         }

--- a/src/utils/findpackage/vcpkg.rs
+++ b/src/utils/findpackage/vcpkg.rs
@@ -5,11 +5,11 @@ use std::sync::{Arc, LazyLock, Mutex};
 
 use super::{
     CMAKECONFIG, CMAKECONFIGVERSION, CMAKEREGEX, SPECIAL_PACKAGE_PATTERN, get_version,
-    handle_config_package
+    handle_config_package,
 };
 use crate::Uri;
-use crate::utils::{CMakePackage, CMakePackageFrom, PackageType};
 use crate::consts::TREESITTER_CMAKE_LANGUAGE;
+use crate::utils::{CMakePackage, CMakePackageFrom, PackageType};
 
 #[inline]
 pub fn did_vcpkg_project(path: &Path) -> bool {
@@ -73,7 +73,7 @@ fn get_cmake_message() -> HashMap<String, CMakePackage> {
                 if CMAKECONFIGVERSION.is_match(file.to_str().unwrap())
                     && let Ok(context) = fs::read_to_string(&file)
                 {
-                    version = get_version(&context.as_bytes(), &mut parser);
+                    version = get_version(context.as_bytes(), &mut parser);
                 }
             }
 
@@ -137,7 +137,7 @@ fn get_cmake_message() -> HashMap<String, CMakePackage> {
                                 if CMAKECONFIGVERSION.is_match(filename)
                                     && let Ok(context) = fs::read_to_string(&filepath)
                                 {
-                                    version = get_version(&context.as_bytes(), &mut parser);
+                                    version = get_version(context.as_bytes(), &mut parser);
                                 }
                             }
                         }

--- a/src/utils/findpackage/vcpkg.rs
+++ b/src/utils/findpackage/vcpkg.rs
@@ -5,11 +5,10 @@ use std::sync::{Arc, LazyLock, Mutex};
 
 use super::{
     CMAKECONFIG, CMAKECONFIGVERSION, CMAKEREGEX, SPECIAL_PACKAGE_PATTERN, get_version,
-    handle_config_package,
+    handle_config_package, get_version_cache
 };
 use crate::Uri;
 use crate::utils::{CMakePackage, CMakePackageFrom, PackageType};
-use crate::consts::TREESITTER_CMAKE_LANGUAGE;
 
 #[inline]
 pub fn did_vcpkg_project(path: &Path) -> bool {
@@ -52,7 +51,7 @@ fn get_cmake_message() -> HashMap<String, CMakePackage> {
     let mut packages: HashMap<String, CMakePackage> = HashMap::new();
     let vcpkg_prefix = VCPKG_PREFIX.lock().unwrap();
     let mut parser = tree_sitter::Parser::new();
-    parser.set_language(&TREESITTER_CMAKE_LANGUAGE).unwrap();
+    let query = get_version_cache(&mut parser);
 
     for lib in vcpkg_prefix.iter() {
         let Ok(paths) = glob::glob(&format!("{lib}/share/*/cmake/")) else {
@@ -73,7 +72,7 @@ fn get_cmake_message() -> HashMap<String, CMakePackage> {
                 if CMAKECONFIGVERSION.is_match(file.to_str().unwrap())
                     && let Ok(context) = fs::read_to_string(&file)
                 {
-                    version = get_version(&context, &mut parser);
+                    version = get_version(&context, &query, &mut parser);
                 }
             }
 
@@ -137,7 +136,7 @@ fn get_cmake_message() -> HashMap<String, CMakePackage> {
                                 if CMAKECONFIGVERSION.is_match(filename)
                                     && let Ok(context) = fs::read_to_string(&filepath)
                                 {
-                                    version = get_version(&context, &mut parser);
+                                    version = get_version(&context, &query, &mut parser);
                                 }
                             }
                         }

--- a/src/utils/findpackage/vcpkg.rs
+++ b/src/utils/findpackage/vcpkg.rs
@@ -5,10 +5,11 @@ use std::sync::{Arc, LazyLock, Mutex};
 
 use super::{
     CMAKECONFIG, CMAKECONFIGVERSION, CMAKEREGEX, SPECIAL_PACKAGE_PATTERN, get_version,
-    handle_config_package, get_version_cache
+    handle_config_package,
 };
 use crate::Uri;
 use crate::utils::{CMakePackage, CMakePackageFrom, PackageType};
+use crate::consts::TREESITTER_CMAKE_LANGUAGE;
 
 #[inline]
 pub fn did_vcpkg_project(path: &Path) -> bool {
@@ -51,7 +52,7 @@ fn get_cmake_message() -> HashMap<String, CMakePackage> {
     let mut packages: HashMap<String, CMakePackage> = HashMap::new();
     let vcpkg_prefix = VCPKG_PREFIX.lock().unwrap();
     let mut parser = tree_sitter::Parser::new();
-    let query = get_version_cache(&mut parser);
+    parser.set_language(&TREESITTER_CMAKE_LANGUAGE).unwrap();
 
     for lib in vcpkg_prefix.iter() {
         let Ok(paths) = glob::glob(&format!("{lib}/share/*/cmake/")) else {
@@ -72,7 +73,7 @@ fn get_cmake_message() -> HashMap<String, CMakePackage> {
                 if CMAKECONFIGVERSION.is_match(file.to_str().unwrap())
                     && let Ok(context) = fs::read_to_string(&file)
                 {
-                    version = get_version(&context, &query, &mut parser);
+                    version = get_version(&context, &mut parser);
                 }
             }
 
@@ -136,7 +137,7 @@ fn get_cmake_message() -> HashMap<String, CMakePackage> {
                                 if CMAKECONFIGVERSION.is_match(filename)
                                     && let Ok(context) = fs::read_to_string(&filepath)
                                 {
-                                    version = get_version(&context, &query, &mut parser);
+                                    version = get_version(&context, &mut parser);
                                 }
                             }
                         }

--- a/src/utils/findpackage/vcpkg.rs
+++ b/src/utils/findpackage/vcpkg.rs
@@ -9,6 +9,7 @@ use super::{
 };
 use crate::Uri;
 use crate::utils::{CMakePackage, CMakePackageFrom, PackageType};
+use crate::consts::TREESITTER_CMAKE_LANGUAGE;
 
 #[inline]
 pub fn did_vcpkg_project(path: &Path) -> bool {
@@ -50,6 +51,9 @@ fn get_available_libs() -> Vec<PathBuf> {
 fn get_cmake_message() -> HashMap<String, CMakePackage> {
     let mut packages: HashMap<String, CMakePackage> = HashMap::new();
     let vcpkg_prefix = VCPKG_PREFIX.lock().unwrap();
+    let mut parser = tree_sitter::Parser::new();
+    parser.set_language(&TREESITTER_CMAKE_LANGUAGE).unwrap();
+
     for lib in vcpkg_prefix.iter() {
         let Ok(paths) = glob::glob(&format!("{lib}/share/*/cmake/")) else {
             continue;
@@ -69,7 +73,7 @@ fn get_cmake_message() -> HashMap<String, CMakePackage> {
                 if CMAKECONFIGVERSION.is_match(file.to_str().unwrap())
                     && let Ok(context) = fs::read_to_string(&file)
                 {
-                    version = get_version(&context);
+                    version = get_version(&context, &mut parser);
                 }
             }
 
@@ -133,7 +137,7 @@ fn get_cmake_message() -> HashMap<String, CMakePackage> {
                                 if CMAKECONFIGVERSION.is_match(filename)
                                     && let Ok(context) = fs::read_to_string(&filepath)
                                 {
-                                    version = get_version(&context);
+                                    version = get_version(&context, &mut parser);
                                 }
                             }
                         }

--- a/src/utils/query.rs
+++ b/src/utils/query.rs
@@ -26,13 +26,17 @@ const FUNCTION_QUERY: &str = r"(
             (argument_list ((argument)*) @args))) @function_def
 )";
 
-pub const NORMAL_COMMAND_QUERY: &str = r"(
+pub const NORMAL_COMMAND_QUERY: &str = r"
+(
     (normal_command) @normal_command
-)";
+)
+";
 
-const VARIABLE_QUERY: &str = r"(
+const VARIABLE_QUERY: &str = r"
+(
     (variable) @variable
-)";
+)
+";
 
 pub struct VariableNode<'a> {
     pub content: &'a str,
@@ -295,14 +299,14 @@ pub fn get_normal_commands<'a>(
         normal_command.identifier = identifier.utf8_text(source).unwrap();
         normal_command.identifier_node = Some(identifier);
         // NOTE: child 1 is "(", it is child 2 that argument_list
-        if let Some(arg_list) = node.child(2)
-            && arg_list.kind() == CMakeNodeKinds::ARGUMENT_LIST
+        if let Some(argument_list) = node.child(2)
+            && argument_list.kind() == CMakeNodeKinds::ARGUMENT_LIST
         {
-            let mut walk = arg_list.walk();
-            for child in arg_list.children(&mut walk) {
+            let mut walk = argument_list.walk();
+            for child in argument_list.children(&mut walk) {
                 normal_command.args.push(child);
             }
-            if let Some(first_arg) = arg_list.child(0) {
+            if let Some(first_arg) = argument_list.child(0) {
                 normal_command.first_arg = first_arg.utf8_text(source).ok();
             }
         }

--- a/src/utils/query.rs
+++ b/src/utils/query.rs
@@ -26,17 +26,13 @@ const FUNCTION_QUERY: &str = r"(
             (argument_list ((argument)*) @args))) @function_def
 )";
 
-pub const NORMAL_COMMAND_QUERY: &str = r"
-(
+pub const NORMAL_COMMAND_QUERY: &str = r"(
     (normal_command) @normal_command
-)
-";
+)";
 
-const VARIABLE_QUERY: &str = r"
-(
+const VARIABLE_QUERY: &str = r"(
     (variable) @variable
-)
-";
+)";
 
 pub struct VariableNode<'a> {
     pub content: &'a str,
@@ -299,14 +295,14 @@ pub fn get_normal_commands<'a>(
         normal_command.identifier = identifier.utf8_text(source).unwrap();
         normal_command.identifier_node = Some(identifier);
         // NOTE: child 1 is "(", it is child 2 that argument_list
-        if let Some(argument_list) = node.child(2)
-            && argument_list.kind() == CMakeNodeKinds::ARGUMENT_LIST
+        if let Some(arg_list) = node.child(2)
+            && arg_list.kind() == CMakeNodeKinds::ARGUMENT_LIST
         {
-            let mut walk = argument_list.walk();
-            for child in argument_list.children(&mut walk) {
+            let mut walk = arg_list.walk();
+            for child in arg_list.children(&mut walk) {
                 normal_command.args.push(child);
             }
-            if let Some(first_arg) = argument_list.child(0) {
+            if let Some(first_arg) = arg_list.child(0) {
                 normal_command.first_arg = first_arg.utf8_text(source).ok();
             }
         }


### PR DESCRIPTION
Maybe a fix to #209
This changed the impl of `get_version()` function
and make it reuse parser